### PR TITLE
feat(hero): full-viewport hero, scroll-down button, and nav polish

### DIFF
--- a/WebContent/css/mediaqueries.css
+++ b/WebContent/css/mediaqueries.css
@@ -30,6 +30,7 @@
 
   #profile {
     height: fit-content;
+    min-height: auto;
     padding-bottom: 2vw;
   }
 

--- a/WebContent/css/style.css
+++ b/WebContent/css/style.css
@@ -68,12 +68,49 @@ p {
   cursor: pointer;
   font-size: 1.2rem;
   opacity: 0;
+  pointer-events: none;
   transition: opacity 300ms ease;
   z-index: 99;
 }
 
 .back-to-top.visible {
   opacity: 1;
+  pointer-events: auto;
+}
+
+/* === Scroll Down === */
+
+@keyframes bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(6px);
+  }
+}
+
+.scroll-down {
+  position: absolute;
+  bottom: 2rem;
+  right: 2rem;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: #353535;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+  opacity: 1;
+  transition: opacity 300ms ease;
+  animation: bounce 1.6s ease-in-out infinite;
+  z-index: 99;
+}
+
+.scroll-down.hidden {
+  opacity: 0;
+  pointer-events: none;
 }
 
 /* === Transition === */
@@ -174,11 +211,12 @@ section {
 #profile {
   position: relative;
   display: flex;
+  align-items: center;
   justify-content: center;
   max-width: 1700px;
   margin: 0 auto;
-  gap: 0.5rem;
-  height: fit-content;
+  gap: 3rem;
+  min-height: calc(100vh - 4rem);
 }
 
 .logo {
@@ -190,8 +228,8 @@ section {
 
 .section__pic-container {
   display: flex;
-  max-height: 400px;
-  max-width: 400px;
+  max-height: 300px;
+  max-width: 300px;
   margin: auto 0;
 }
 

--- a/WebContent/js/script.js
+++ b/WebContent/js/script.js
@@ -28,18 +28,44 @@ document.addEventListener('DOMContentLoaded', () => {
 /* === Back to Top Button === */
 
 /**
- * Shows the back-to-top button after scrolling 400px and scrolls to top on click.
+ * Shows the back-to-top button once the testimonials section scrolls into view.
  */
 document.addEventListener('DOMContentLoaded', () => {
   const backToTop = document.querySelector('.back-to-top');
+  const testimonials = document.querySelector('#testimonials');
 
   if (backToTop) {
     window.addEventListener('scroll', () => {
-      backToTop.classList.toggle('visible', window.scrollY > 400);
+      const testimonialsTop = testimonials ? testimonials.getBoundingClientRect().top : Infinity;
+      backToTop.classList.toggle('visible', testimonialsTop <= window.innerHeight);
     });
 
     backToTop.addEventListener('click', () => {
       window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  }
+});
+
+/* === Scroll Down Button === */
+
+/**
+ * Hides the scroll-down arrow once the user has scrolled past the profile section.
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  const scrollDown = document.querySelector('.scroll-down');
+  const profileSection = document.querySelector('#profile');
+
+  if (scrollDown && profileSection) {
+    window.addEventListener('scroll', () => {
+      const profileBottom = profileSection.getBoundingClientRect().bottom;
+      scrollDown.classList.toggle('hidden', profileBottom < 0);
+    });
+
+    scrollDown.addEventListener('click', () => {
+      const skills = document.querySelector('#skills');
+      const nav = document.querySelector('#main-nav');
+      const navHeight = nav ? nav.offsetHeight : 0;
+      window.scrollTo({ top: skills.offsetTop - navHeight, behavior: 'smooth' });
     });
   }
 });

--- a/index.html
+++ b/index.html
@@ -92,6 +92,7 @@
           </div>
         </div>
       </div>
+      <button class="scroll-down" aria-label="Scroll to skills section">↓</button>
     </section>
     <section id="skills">
       <div class="skills-header">


### PR DESCRIPTION
- Hero section fills viewport on load (min-height: calc(100vh - 4rem)) with content vertically centered via align-items: center
- Profile image container reduced to 300x300px; gap increased to 3rem
- Add scroll-down arrow button (bottom-right of hero) that bounces and scrolls smoothly to #skills; hides once hero scrolls off screen
- Fix back-to-top pointer-events so it doesn't intercept clicks while invisible (pointer-events: none until .visible)
- Back-to-top now appears only when #testimonials enters the viewport