### PR TITLE
feat: add multi-turn conversation history and context updates

### DIFF
--- a/WebContent/context/housing-affordability.md
+++ b/WebContent/context/housing-affordability.md
@@ -2,7 +2,7 @@
 
 ## Classification
 
-- **Type:** Independent
+- **Type:** Capstone Project — Arizona State University
 - **Status:** Complete
 - **Featured:** Yes
 

--- a/WebContent/js/chat.js
+++ b/WebContent/js/chat.js
@@ -120,11 +120,11 @@ const createLoadingHtml = () => {
  * @returns {Promise<string>} The assistant's response text.
  * @throws {Error} If the request fails or returns a non-OK status.
  */
-const sendMessage = async (message) => {
+const sendMessage = async (messages) => {
   const response = await fetch(LAMBDA_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ message }),
+    body: JSON.stringify({ messages }),
   });
 
   if (!response.ok) {
@@ -156,6 +156,7 @@ export function initChat() {
   }
 
   let isProcessing = false;
+  const conversationHistory = [];
 
   /** Appends HTML to the messages container and scrolls to bottom. */
   const appendMessage = (html) => {
@@ -201,11 +202,14 @@ export function initChat() {
 
     try {
       recordRequest();
-      const response = await sendMessage(message);
+      conversationHistory.push({ role: 'user', content: message });
+      const response = await sendMessage(conversationHistory);
 
       // Remove loading indicator
       const loading = document.getElementById('chat-loading');
       if (loading) loading.remove();
+
+      conversationHistory.push({ role: 'assistant', content: response });
 
       // Show assistant response
       appendMessage(formatMessage(response, 'assistant'));

--- a/index.html
+++ b/index.html
@@ -596,7 +596,12 @@
               maxlength="1000"
               autocomplete="off"
             />
-            <button id="chat-send" class="btn btn-color-1 chat-send" aria-label="Send message">
+            <button
+              type="button"
+              id="chat-send"
+              class="btn btn-color-1 chat-send"
+              aria-label="Send message"
+            >
               Send
             </button>
           </div>

--- a/lambda/knowledge_base.json
+++ b/lambda/knowledge_base.json
@@ -318,7 +318,7 @@
     },
     {
       "title": "Housing Affordability & Commute Trade-Off Analysis",
-      "type": "Independent",
+      "type": "Capstone Project — Arizona State University",
       "status": "Complete",
       "featured": true,
       "summary": "A data engineering and statistical analysis pipeline that quantifies the relationship between housing costs, commute time, and public transit accessibility across nine U.S. metropolitan areas. Charles built the entire project end-to-end — from data ingestion to regression analysis — to answer real research questions about where housing affordability and commute burdens intersect.",

--- a/lambda/lambda_function.py
+++ b/lambda/lambda_function.py
@@ -107,7 +107,7 @@ def get_anthropic_client() -> anthropic.Anthropic:
     return anthropic.Anthropic()
 
 
-def parse_request(body: str | None) -> str:
+def parse_request(body: str | None) -> list[dict[str, str]]:
     """Parse and validate the incoming request body.
 
     Parameters
@@ -117,14 +117,13 @@ def parse_request(body: str | None) -> str:
 
     Returns
     -------
-    str
-        The validated user message.
+    list[dict[str, str]]
+        Validated conversation messages for the Anthropic API.
 
     Raises
     ------
     ValueError
-        If the body is missing, not valid JSON, missing the 'message' key,
-        or the message is empty or too long.
+        If the body is missing, not valid JSON, or messages are invalid.
     """
     if not body:
         raise ValueError("Request body is empty")
@@ -132,14 +131,34 @@ def parse_request(body: str | None) -> str:
         data = json.loads(body)
     except json.JSONDecodeError as exc:
         raise ValueError("Invalid JSON in request body") from exc
-    if "message" not in data:
-        raise ValueError("Missing 'message' key in request body")
-    message = data["message"].strip()
-    if not message:
-        raise ValueError("Message is empty")
-    if len(message) > MAX_MESSAGE_LENGTH:
-        raise ValueError(f"Message too long (max {MAX_MESSAGE_LENGTH} characters)")
-    return message
+
+    # Support both single message and conversation history
+    if "messages" in data:
+        messages = data["messages"]
+        if not isinstance(messages, list) or not messages:
+            raise ValueError("Messages must be a non-empty array")
+        # Validate the latest user message
+        last = messages[-1]
+        if last.get("role") != "user" or not last.get("content", "").strip():
+            raise ValueError("Last message must be a non-empty user message")
+        if len(last["content"]) > MAX_MESSAGE_LENGTH:
+            raise ValueError(f"Message too long (max {MAX_MESSAGE_LENGTH} characters)")
+        # Sanitize: only allow role and content keys, limit history length
+        allowed_roles = {"user", "assistant"}
+        clean = []
+        for m in messages[-10:]:  # Keep last 10 messages (5 turns)
+            if m.get("role") in allowed_roles and m.get("content"):
+                clean.append({"role": m["role"], "content": m["content"]})
+        return clean
+    elif "message" in data:
+        message = data["message"].strip()
+        if not message:
+            raise ValueError("Message is empty")
+        if len(message) > MAX_MESSAGE_LENGTH:
+            raise ValueError(f"Message too long (max {MAX_MESSAGE_LENGTH} characters)")
+        return [{"role": "user", "content": message}]
+    else:
+        raise ValueError("Missing 'message' or 'messages' key in request body")
 
 
 def build_response(status_code: int, body: dict[str, Any]) -> dict[str, Any]:
@@ -190,7 +209,7 @@ def handler(event: dict, context: Any) -> dict[str, Any]:
         return build_response(405, {"error": "Method not allowed"})
 
     try:
-        message = parse_request(event.get("body"))
+        messages = parse_request(event.get("body"))
     except ValueError as e:
         return build_response(400, {"error": str(e)})
 
@@ -200,7 +219,7 @@ def handler(event: dict, context: Any) -> dict[str, Any]:
             model=MODEL_ID,
             max_tokens=MAX_TOKENS,
             system=build_system_prompt(),
-            messages=[{"role": "user", "content": message}],
+            messages=messages,
         )
         assistant_text = response.content[0].text
         return build_response(200, {"response": assistant_text})


### PR DESCRIPTION
- Send full conversation history to Lambda for contextual follow-ups
- Lambda accepts messages array, sanitizes and limits to last 10 messages
- Backwards-compatible: still supports single message format
- Update housing affordability project type to ASU capstone
- Add type="button" to chat send button
- Rebuild knowledge base with updated context