### PR TITLE
feat(chat): move AI assistant into hero section

### DIFF
--- a/WebContent/css/mediaqueries.css
+++ b/WebContent/css/mediaqueries.css
@@ -185,6 +185,10 @@
 
   /* === Chat Agent === */
 
+  .hero-chat {
+    padding: 0 1rem;
+  }
+
   .chat-container h2 {
     text-align: center;
   }

--- a/WebContent/css/style.css
+++ b/WebContent/css/style.css
@@ -256,11 +256,18 @@ section {
   position: relative;
   display: flex;
   align-items: center;
-  justify-content: center;
+  place-content: center center;
+  flex-wrap: wrap;
   max-width: 1700px;
   margin: 0 auto;
-  gap: 3rem;
+  gap: 4rem 3rem;
   min-height: calc(100vh - 4rem);
+}
+
+.hero-chat {
+  flex-basis: 100%;
+  max-width: 700px;
+  margin: 0 auto;
 }
 
 .logo {
@@ -489,10 +496,7 @@ section {
 /* === Chat Agent Section === */
 
 #chat-agent {
-  padding: 2rem;
-  background-color: var(--color-bg-white);
-  max-width: 800px;
-  margin: 2rem auto;
+  padding: 0;
 }
 
 .chat-container {

--- a/index.html
+++ b/index.html
@@ -97,6 +97,41 @@
             </div>
           </div>
         </div>
+        <div id="chat-agent" class="hero-chat">
+          <div class="chat-container">
+            <h2 class="section_text__p1">Ask Me Anything</h2>
+            <p class="chat-subtitle">
+              Have a question about my projects, skills, or experience? Ask my AI assistant.
+            </p>
+            <div id="chat-messages" class="chat-messages" aria-live="polite" role="log">
+              <div class="chat-message assistant">
+                <p>
+                  Hi! I'm Charles's AI assistant. Ask me about his projects, skills, or experience.
+                </p>
+              </div>
+            </div>
+            <div class="chat-input-row">
+              <input
+                type="text"
+                id="chat-input"
+                class="chat-input"
+                placeholder="e.g., What projects use Python?"
+                aria-label="Type your question"
+                maxlength="1000"
+                autocomplete="off"
+              />
+              <button
+                type="button"
+                id="chat-send"
+                class="btn btn-color-1 chat-send"
+                aria-label="Send message"
+              >
+                Send
+              </button>
+            </div>
+            <p id="chat-rate-limit" class="chat-rate-limit" hidden></p>
+          </div>
+        </div>
         <button class="scroll-down" aria-label="Scroll to skills section">↓</button>
       </section>
       <section id="skills">
@@ -152,41 +187,6 @@
         <div class="projects-grid"></div>
         <div class="projects-footer">
           <a href="./projects.html" class="btn btn-color-1 view-all-link">View All Projects</a>
-        </div>
-      </section>
-      <section id="chat-agent">
-        <div class="chat-container">
-          <h2 class="section_text__p1">Ask Me Anything</h2>
-          <p class="chat-subtitle">
-            Have a question about my projects, skills, or experience? Ask my AI assistant.
-          </p>
-          <div id="chat-messages" class="chat-messages" aria-live="polite" role="log">
-            <div class="chat-message assistant">
-              <p>
-                Hi! I'm Charles's AI assistant. Ask me about his projects, skills, or experience.
-              </p>
-            </div>
-          </div>
-          <div class="chat-input-row">
-            <input
-              type="text"
-              id="chat-input"
-              class="chat-input"
-              placeholder="e.g., What projects use Python?"
-              aria-label="Type your question"
-              maxlength="1000"
-              autocomplete="off"
-            />
-            <button
-              type="button"
-              id="chat-send"
-              class="btn btn-color-1 chat-send"
-              aria-label="Send message"
-            >
-              Send
-            </button>
-          </div>
-          <p id="chat-rate-limit" class="chat-rate-limit" hidden></p>
         </div>
       </section>
       <section id="testimonials">

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -140,44 +140,40 @@ class TestProjectsPageValidation:
 
 @pytest.mark.validation
 class TestChatSectionValidation:
-    """Validate the chat agent section HTML structure."""
+    """Validate the chat agent HTML structure (embedded in profile/hero section)."""
 
-    def test_chat_section_exists(self, soup):
-        section = soup.find('section', id='chat-agent')
-        assert section is not None, 'Missing <section id="chat-agent">'
+    def test_chat_agent_exists(self, soup):
+        chat = soup.find(id='chat-agent')
+        assert chat is not None, 'Missing element with id="chat-agent"'
 
-    def test_chat_section_has_heading(self, soup):
-        section = soup.find('section', id='chat-agent')
-        assert section is not None
-        h2 = section.find('h2')
+    def test_chat_agent_inside_profile(self, soup):
+        profile = soup.find('section', id='profile')
+        assert profile is not None, 'Missing <section id="profile">'
+        chat = profile.find(id='chat-agent')
+        assert chat is not None, 'chat-agent must be inside the profile section'
+
+    def test_chat_has_heading(self, soup):
+        chat = soup.find(id='chat-agent')
+        assert chat is not None
+        h2 = chat.find('h2')
         assert h2 is not None, 'Chat section missing <h2> heading'
 
-    def test_chat_section_between_projects_and_testimonials(self, soup):
-        sections = [s.get('id') for s in soup.find_all('section') if s.get('id')]
-        assert 'chat-agent' in sections, 'chat-agent section not found'
-        projects_idx = sections.index('projects')
-        chat_idx = sections.index('chat-agent')
-        testimonials_idx = sections.index('testimonials')
-        assert projects_idx < chat_idx < testimonials_idx, (
-            f'Section order wrong: projects={projects_idx}, chat={chat_idx}, testimonials={testimonials_idx}'
-        )
-
     def test_chat_input_exists(self, soup):
-        section = soup.find('section', id='chat-agent')
-        assert section is not None
-        input_el = section.find('input', id='chat-input')
+        chat = soup.find(id='chat-agent')
+        assert chat is not None
+        input_el = chat.find('input', id='chat-input')
         assert input_el is not None, 'Missing chat input field'
 
     def test_chat_send_button_exists(self, soup):
-        section = soup.find('section', id='chat-agent')
-        assert section is not None
-        btn = section.find('button', id='chat-send')
+        chat = soup.find(id='chat-agent')
+        assert chat is not None
+        btn = chat.find('button', id='chat-send')
         assert btn is not None, 'Missing chat send button'
 
     def test_chat_messages_container_exists(self, soup):
-        section = soup.find('section', id='chat-agent')
-        assert section is not None
-        messages = section.find('div', id='chat-messages')
+        chat = soup.find(id='chat-agent')
+        assert chat is not None
+        messages = chat.find('div', id='chat-messages')
         assert messages is not None, 'Missing chat messages container'
 
     def test_chat_input_has_aria_label(self, soup):


### PR DESCRIPTION
## Summary
- Moves the AI chat assistant from a standalone section (between Projects and Testimonials) into the hero/profile section, directly below the bio content
- Makes the chat one of the first things visitors see, encouraging engagement
- Updates CSS with `flex-wrap` and `align-content` to cleanly position the chat below the photo + bio row
- Adds mobile padding for the embedded chat at smaller breakpoints
- Updates pytest chat validation tests to reflect the new DOM structure

Closes #95

## Test plan
- [x] All 132 pytest tests pass (including updated chat validation tests)
- [x] All 87 Jest tests pass
- [x] Prettier formatting passes on all changed files
- [x] Visual check: chat is visible in hero section without excessive scrolling
- [x] Visual check: mobile layout is clean and chat doesn't dominate small screens
- [x] Verify nav "Ask AI" link scrolls to the chat within the hero section

🤖 Generated with [Claude Code](https://claude.com/claude-code)