### PR TITLE
fix(chat): hero chat layout and scroll button overlap

### DIFF
--- a/WebContent/css/mediaqueries.css
+++ b/WebContent/css/mediaqueries.css
@@ -29,6 +29,14 @@
     padding-bottom: 2vw;
   }
 
+  .hero-chat {
+    margin-top: 3rem;
+  }
+
+  .scroll-down {
+    display: none;
+  }
+
   #profile,
   .section-container {
     display: block;

--- a/WebContent/css/style.css
+++ b/WebContent/css/style.css
@@ -266,6 +266,7 @@ section {
 
 .hero-chat {
   flex-basis: 100%;
+  min-width: 100%;
   max-width: 700px;
   margin: 0 auto;
 }


### PR DESCRIPTION
## Summary
- Adds `min-width: 100%` to `.hero-chat` so the chat always wraps below the profile content instead of sitting side-by-side at ~1250px
- Adds `margin-top: 3rem` at the 1250px breakpoint to restore spacing when layout switches to `display: block`
- Hides the scroll-down arrow at smaller screens to prevent it overlapping the chat send button

## Test plan
- [x] All 132 pytest tests pass
- [x] All 87 Jest tests pass
- [x] Prettier formatting passes
- [x] Visual check: chat stays below hero content at all viewport widths
- [x] Visual check: send button is not obscured at any breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)