### PR TITLE
fix(carousel): align JS breakpoint with CSS media query (1250px)

### DIFF
--- a/WebContent/js/carousel.js
+++ b/WebContent/js/carousel.js
@@ -4,7 +4,7 @@ import { getItemsToShow, isDesktop } from './utils.js';
 
 /** Configuration constants for testimonial carousel behavior */
 export const CAROUSEL_CONFIG = {
-  DESKTOP_BREAKPOINT: 1200,
+  DESKTOP_BREAKPOINT: 1250, // Must match mediaqueries.css @media breakpoint
   AUTO_SCROLL_INTERVAL_MS: 20000,
   TESTIMONIALS_DESKTOP: 2,
   TESTIMONIALS_MOBILE: 1,

--- a/__tests__/carousel.test.js
+++ b/__tests__/carousel.test.js
@@ -1,10 +1,17 @@
 import {
+  CAROUSEL_CONFIG,
   getNextIndex,
   getPrevIndex,
   getDotCount,
   getActiveDotIndex,
   getCounterText,
 } from '../WebContent/js/carousel.js';
+
+describe('CAROUSEL_CONFIG', () => {
+  test('DESKTOP_BREAKPOINT matches CSS media query (1250px)', () => {
+    expect(CAROUSEL_CONFIG.DESKTOP_BREAKPOINT).toBe(1250);
+  });
+});
 
 describe('getNextIndex', () => {
   test('advances by step when not at end', () => {


### PR DESCRIPTION
## Summary
- The carousel `DESKTOP_BREAKPOINT` (1200px) disagreed with the CSS media query breakpoint in `mediaqueries.css` (1250px), creating a 50px window where the carousel showed mobile behavior inside a desktop CSS layout
- Changed `DESKTOP_BREAKPOINT` to 1250 with a comment noting the CSS dependency
- Added a drift-prevention test asserting the value matches

## Test plan
- [x] New test: `DESKTOP_BREAKPOINT matches CSS media query (1250px)`
- [ ] All 88 Jest tests pass (87 existing + 1 new)
- [ ] Manual verification: at 1225px viewport, carousel shows 2 items (desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)