### PR TITLE
refactor(chat): add injectable dependencies for testability

### DIFF
--- a/WebContent/js/chat.js
+++ b/WebContent/js/chat.js
@@ -28,13 +28,14 @@ export const escapeHtml = (text) => {
 };
 
 /**
- * Gets non-expired request timestamps from localStorage.
+ * Gets non-expired request timestamps from storage.
  *
+ * @param {Storage} storage - Storage backend (defaults to localStorage).
  * @returns {number[]} Timestamps within the current rate limit window.
  */
-const getValidTimestamps = () => {
+const getValidTimestamps = (storage = localStorage) => {
   try {
-    const raw = localStorage.getItem(RATE_LIMIT_CONFIG.STORAGE_KEY);
+    const raw = storage.getItem(RATE_LIMIT_CONFIG.STORAGE_KEY);
     if (!raw) return [];
     const timestamps = JSON.parse(raw);
     const cutoff = Date.now() - RATE_LIMIT_CONFIG.WINDOW_MS;
@@ -47,28 +48,32 @@ const getValidTimestamps = () => {
 /**
  * Checks if the user has exceeded the rate limit.
  *
+ * @param {Storage} [storage=localStorage] - Storage backend for rate limit data.
  * @returns {boolean} True if rate limited.
  */
-export const isRateLimited = () => {
-  return getValidTimestamps().length >= RATE_LIMIT_CONFIG.MAX_REQUESTS;
+export const isRateLimited = (storage = localStorage) => {
+  return getValidTimestamps(storage).length >= RATE_LIMIT_CONFIG.MAX_REQUESTS;
 };
 
 /**
- * Records a new request timestamp in localStorage.
+ * Records a new request timestamp in storage.
+ *
+ * @param {Storage} [storage=localStorage] - Storage backend for rate limit data.
  */
-export const recordRequest = () => {
-  const timestamps = getValidTimestamps();
+export const recordRequest = (storage = localStorage) => {
+  const timestamps = getValidTimestamps(storage);
   timestamps.push(Date.now());
-  localStorage.setItem(RATE_LIMIT_CONFIG.STORAGE_KEY, JSON.stringify(timestamps));
+  storage.setItem(RATE_LIMIT_CONFIG.STORAGE_KEY, JSON.stringify(timestamps));
 };
 
 /**
  * Returns the number of remaining requests in the current window.
  *
+ * @param {Storage} [storage=localStorage] - Storage backend for rate limit data.
  * @returns {number} Remaining requests (0 or positive).
  */
-export const getRemainingRequests = () => {
-  return Math.max(0, RATE_LIMIT_CONFIG.MAX_REQUESTS - getValidTimestamps().length);
+export const getRemainingRequests = (storage = localStorage) => {
+  return Math.max(0, RATE_LIMIT_CONFIG.MAX_REQUESTS - getValidTimestamps(storage).length);
 };
 
 /**
@@ -116,12 +121,15 @@ const createLoadingHtml = () => {
 /**
  * Sends a message to the Lambda function.
  *
- * @param {string} message - User's question.
+ * @param {Array<{role: string, content: string}>} messages - Conversation history.
+ * @param {Object} options - Send options.
+ * @param {string} options.apiUrl - API endpoint URL.
+ * @param {Function} options.fetchFn - Fetch implementation.
  * @returns {Promise<string>} The assistant's response text.
  * @throws {Error} If the request fails or returns a non-OK status.
  */
-const sendMessage = async (messages) => {
-  const response = await fetch(LAMBDA_URL, {
+const sendMessage = async (messages, { apiUrl, fetchFn }) => {
+  const response = await fetchFn(apiUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ messages }),
@@ -144,8 +152,14 @@ const sendMessage = async (messages) => {
  * Wires up the send button and Enter key to submit messages,
  * displays responses, and manages rate limiting UI.
  * Only runs when the required DOM elements exist.
+ *
+ * @param {Object} [options] - Optional dependency overrides.
+ * @param {string} [options.apiUrl] - API endpoint URL (defaults to LAMBDA_URL).
+ * @param {Function} [options.fetchFn] - Fetch implementation (defaults to global fetch).
+ * @param {Storage} [options.storage] - Storage backend (defaults to localStorage).
  */
-export function initChat() {
+export function initChat({ apiUrl = LAMBDA_URL, fetchFn, storage = localStorage } = {}) {
+  const resolvedFetch = fetchFn || globalThis.fetch;
   const chatInput = document.getElementById('chat-input');
   const chatSend = document.getElementById('chat-send');
   const chatMessages = document.getElementById('chat-messages');
@@ -171,7 +185,7 @@ export function initChat() {
 
   /** Updates the rate limit warning text and disables input at zero. */
   const updateRateLimitDisplay = () => {
-    const remaining = getRemainingRequests();
+    const remaining = getRemainingRequests(storage);
     if (remaining <= 3 && remaining > 0) {
       chatRateLimit.textContent = `${remaining} question${remaining === 1 ? '' : 's'} remaining this hour`;
       chatRateLimit.hidden = false;
@@ -190,7 +204,7 @@ export function initChat() {
     const message = chatInput.value.trim();
     if (!message || isProcessing) return;
 
-    if (isRateLimited()) {
+    if (isRateLimited(storage)) {
       updateRateLimitDisplay();
       return;
     }
@@ -206,9 +220,9 @@ export function initChat() {
     appendMessage(createLoadingHtml());
 
     try {
-      recordRequest();
+      recordRequest(storage);
       conversationHistory.push({ role: 'user', content: message });
-      const response = await sendMessage(conversationHistory);
+      const response = await sendMessage(conversationHistory, { apiUrl, fetchFn: resolvedFetch });
 
       // Remove loading indicator
       const loading = document.getElementById('chat-loading');

--- a/__tests__/chat.test.js
+++ b/__tests__/chat.test.js
@@ -1,11 +1,41 @@
+import { jest } from '@jest/globals';
 import {
   isRateLimited,
   recordRequest,
   getRemainingRequests,
   formatMessage,
   escapeHtml,
+  initChat,
   RATE_LIMIT_CONFIG,
 } from '../WebContent/js/chat.js';
+
+// --- Helper: set up the chat DOM elements ---
+const setupChatDom = () => {
+  document.body.innerHTML = `
+    <input id="chat-input" />
+    <button id="chat-send">Send</button>
+    <div id="chat-messages"></div>
+    <div id="chat-rate-limit" hidden></div>
+  `;
+};
+
+// --- Helper: create a fake storage object ---
+const createFakeStorage = (initialData = {}) => {
+  const store = { ...initialData };
+  return {
+    getItem: (key) => (key in store ? store[key] : null),
+    setItem: (key, value) => {
+      store[key] = String(value);
+    },
+    removeItem: (key) => {
+      delete store[key];
+    },
+    clear: () => {
+      for (const key of Object.keys(store)) delete store[key];
+    },
+    _store: store,
+  };
+};
 
 describe('Rate Limiting', () => {
   beforeEach(() => {
@@ -40,6 +70,48 @@ describe('Rate Limiting', () => {
     const expired = Date.now() - RATE_LIMIT_CONFIG.WINDOW_MS - 1000;
     localStorage.setItem(RATE_LIMIT_CONFIG.STORAGE_KEY, JSON.stringify([expired]));
     expect(isRateLimited()).toBe(false);
+    expect(getRemainingRequests()).toBe(RATE_LIMIT_CONFIG.MAX_REQUESTS);
+  });
+});
+
+describe('Rate Limiting with injected storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('isRateLimited uses injected storage instead of localStorage', () => {
+    const fakeStorage = createFakeStorage();
+    expect(isRateLimited(fakeStorage)).toBe(false);
+
+    // Fill up the storage to the limit
+    const timestamps = [];
+    for (let i = 0; i < RATE_LIMIT_CONFIG.MAX_REQUESTS; i++) {
+      timestamps.push(Date.now());
+    }
+    fakeStorage.setItem(RATE_LIMIT_CONFIG.STORAGE_KEY, JSON.stringify(timestamps));
+
+    expect(isRateLimited(fakeStorage)).toBe(true);
+    // localStorage should remain untouched
+    expect(isRateLimited()).toBe(false);
+  });
+
+  test('recordRequest uses injected storage instead of localStorage', () => {
+    const fakeStorage = createFakeStorage();
+    recordRequest(fakeStorage);
+
+    const stored = JSON.parse(fakeStorage.getItem(RATE_LIMIT_CONFIG.STORAGE_KEY));
+    expect(stored).toHaveLength(1);
+    // localStorage should remain untouched
+    expect(localStorage.getItem(RATE_LIMIT_CONFIG.STORAGE_KEY)).toBeNull();
+  });
+
+  test('getRemainingRequests uses injected storage instead of localStorage', () => {
+    const fakeStorage = createFakeStorage();
+    expect(getRemainingRequests(fakeStorage)).toBe(RATE_LIMIT_CONFIG.MAX_REQUESTS);
+
+    recordRequest(fakeStorage);
+    expect(getRemainingRequests(fakeStorage)).toBe(RATE_LIMIT_CONFIG.MAX_REQUESTS - 1);
+    // localStorage should still show full remaining
     expect(getRemainingRequests()).toBe(RATE_LIMIT_CONFIG.MAX_REQUESTS);
   });
 });
@@ -82,5 +154,179 @@ describe('formatMessage', () => {
   test('does not escape assistant messages (trusted content)', () => {
     const html = formatMessage('Check <strong>this</strong> out', 'assistant');
     expect(html).toContain('<strong>this</strong>');
+  });
+});
+
+describe('initChat', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = '';
+  });
+
+  test('returns early when DOM elements are missing', () => {
+    document.body.innerHTML = '<div>no chat elements</div>';
+    // Should not throw
+    expect(() => initChat()).not.toThrow();
+  });
+
+  test('sends message via fake fetch and displays response', async () => {
+    setupChatDom();
+
+    const fakeFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: 'Hello from the assistant!' }),
+    });
+
+    initChat({ fetchFn: fakeFetch, apiUrl: 'https://fake.api/chat' });
+
+    const input = document.getElementById('chat-input');
+    const sendButton = document.getElementById('chat-send');
+    const messages = document.getElementById('chat-messages');
+
+    input.value = 'Hi there';
+    sendButton.click();
+
+    // Wait for async fetch to resolve
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fakeFetch).toHaveBeenCalledWith(
+      'https://fake.api/chat',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    expect(messages.innerHTML).toContain('Hi there');
+    expect(messages.innerHTML).toContain('Hello from the assistant!');
+  });
+
+  test('displays error message when fetch fails', async () => {
+    setupChatDom();
+
+    const fakeFetch = jest.fn().mockRejectedValue(new Error('Network error'));
+
+    initChat({ fetchFn: fakeFetch, apiUrl: 'https://fake.api/chat' });
+
+    const input = document.getElementById('chat-input');
+    const sendButton = document.getElementById('chat-send');
+    const messages = document.getElementById('chat-messages');
+
+    input.value = 'Hi there';
+    sendButton.click();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(messages.innerHTML).toContain('Sorry, something went wrong');
+  });
+
+  test('uses injected storage for rate limiting', async () => {
+    setupChatDom();
+
+    const fakeStorage = createFakeStorage();
+    const fakeFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: 'OK' }),
+    });
+
+    initChat({ fetchFn: fakeFetch, apiUrl: 'https://fake.api/chat', storage: fakeStorage });
+
+    const input = document.getElementById('chat-input');
+    const sendButton = document.getElementById('chat-send');
+
+    input.value = 'test message';
+    sendButton.click();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The fake storage should have a recorded request
+    const stored = JSON.parse(fakeStorage.getItem(RATE_LIMIT_CONFIG.STORAGE_KEY));
+    expect(stored).toHaveLength(1);
+    // localStorage should remain untouched
+    expect(localStorage.getItem(RATE_LIMIT_CONFIG.STORAGE_KEY)).toBeNull();
+  });
+
+  test('disables input when rate limit is at zero', () => {
+    setupChatDom();
+
+    // Pre-fill storage with max requests
+    const timestamps = [];
+    for (let i = 0; i < RATE_LIMIT_CONFIG.MAX_REQUESTS; i++) {
+      timestamps.push(Date.now());
+    }
+    const fakeStorage = createFakeStorage({
+      [RATE_LIMIT_CONFIG.STORAGE_KEY]: JSON.stringify(timestamps),
+    });
+
+    initChat({ storage: fakeStorage, apiUrl: 'https://fake.api/chat', fetchFn: jest.fn() });
+
+    const input = document.getElementById('chat-input');
+    const sendButton = document.getElementById('chat-send');
+    const rateLimit = document.getElementById('chat-rate-limit');
+
+    expect(input.disabled).toBe(true);
+    expect(sendButton.disabled).toBe(true);
+    expect(rateLimit.hidden).toBe(false);
+    expect(rateLimit.textContent).toContain('Rate limit reached');
+  });
+
+  test('passes full conversation history to fetch', async () => {
+    setupChatDom();
+
+    const fakeFetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ response: 'First response' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ response: 'Second response' }),
+      });
+
+    initChat({ fetchFn: fakeFetch, apiUrl: 'https://fake.api/chat' });
+
+    const input = document.getElementById('chat-input');
+    const sendButton = document.getElementById('chat-send');
+
+    // Send first message
+    input.value = 'First question';
+    sendButton.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Send second message
+    input.value = 'Second question';
+    sendButton.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Second call should include full history
+    const secondCallBody = JSON.parse(fakeFetch.mock.calls[1][1].body);
+    expect(secondCallBody.messages).toEqual([
+      { role: 'assistant', content: expect.stringContaining('AI assistant') },
+      { role: 'user', content: 'First question' },
+      { role: 'assistant', content: 'First response' },
+      { role: 'user', content: 'Second question' },
+    ]);
+  });
+
+  test('Enter key triggers message send', async () => {
+    setupChatDom();
+
+    const fakeFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: 'Response' }),
+    });
+
+    initChat({ fetchFn: fakeFetch, apiUrl: 'https://fake.api/chat' });
+
+    const input = document.getElementById('chat-input');
+    const messages = document.getElementById('chat-messages');
+
+    input.value = 'Enter key test';
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fakeFetch).toHaveBeenCalled();
+    expect(messages.innerHTML).toContain('Enter key test');
   });
 });


### PR DESCRIPTION
## Summary
- `initChat()` now accepts `{ apiUrl, fetchFn, storage }` options bag with production defaults — zero changes needed in `main.js`
- Rate-limit functions (`isRateLimited`, `recordRequest`, `getRemainingRequests`) accept optional `storage` parameter for test isolation
- `sendMessage` closes over injected `apiUrl` and `fetchFn` instead of hardcoded globals
- 9 new tests covering fake fetch (success/failure), fake storage, rate limiting, conversation history, Enter key submission, and missing DOM elements

## Test plan
- [x] 9 new boundary tests added
- [ ] All 97 Jest tests pass (88 existing + 9 new)
- [ ] Existing `main.js` call site (`initChat()` with no args) unchanged
- [ ] Manual verification: chat widget works in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)