### PR TITLE
feat(work): point WAGA card to live dashboard

### DIFF
--- a/src/data/portfolio.js
+++ b/src/data/portfolio.js
@@ -109,7 +109,7 @@ export const projects = [
       'A production-grade ELT pipeline for weather-normalized renewable-asset performance — dlt ingestion into Snowflake, dbt transformations through a semantic layer, and Polars analytics, all orchestrated by Dagster.',
     slug: 'waga',
     tags: ['Python', 'ETL/ELT', 'Data Pipelines'],
-    href: 'https://github.com/cdcoonce/Weather-Adjusted-Generation-Analytics',
+    href: 'https://waga-dashboard.pages.dev',
     featured: true,
   },
   {


### PR DESCRIPTION
Repoint the featured **Weather-Adjusted Generation Analytics** project card from the GitHub repo to the now-live dashboard.

- `src/data/portfolio.js` — WAGA card `href` → `https://waga-dashboard.pages.dev`
- Card keeps its `slug: 'waga'` cockpit-SVG hero; only the outbound link changes.

Follows WAGA static-dashboard Task 9. The Cloudflare Pages project is live with real Snowflake data, so the link resolves.

**CI gate (local):** `npm test` 26/26 ✓ · `npm run lint` (css+js) ✓ · `npm run build` ✓ · new URL confirmed in built bundle, stale GitHub href gone.