### PR TITLE
feat(work): dual View Dashboard / View Repository buttons on WAGA card

### DIFF
--- a/__tests__/portfolio-featured.test.js
+++ b/__tests__/portfolio-featured.test.js
@@ -19,3 +19,24 @@ describe('featuredProjects', () => {
     expect(featuredProjects(sample)).toEqual([{ featured: true }]);
   });
 });
+
+describe('WAGA card links', () => {
+  const waga = projects.find((p) => p.slug === 'waga');
+
+  test('exposes both a Dashboard and a Repository link', () => {
+    expect(waga).toBeDefined();
+    expect(waga.links).toEqual([
+      { label: 'View Dashboard', href: 'https://waga-dashboard.pages.dev' },
+      {
+        label: 'View Repository',
+        href: 'https://github.com/cdcoonce/Weather-Adjusted-Generation-Analytics',
+      },
+    ]);
+  });
+
+  test('every link is an absolute URL', () => {
+    for (const link of waga.links) {
+      expect(link.href).toMatch(/^https?:\/\//);
+    }
+  });
+});

--- a/src/components/tabs/Overview.jsx
+++ b/src/components/tabs/Overview.jsx
@@ -76,14 +76,32 @@ export default function Overview() {
                 <Tag key={t}>{t}</Tag>
               ))}
             </div>
-            <Button
-              size="sm"
-              href={current.href}
-              className="featured__cta"
-              {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-            >
-              {current.ctaLabel ?? 'View repository'}
-            </Button>
+            {current.links?.length ? (
+              <div className="featured__cta-group">
+                {current.links.map((link, i) => (
+                  <Button
+                    key={link.href}
+                    size="sm"
+                    href={link.href}
+                    variant={i === 0 ? 'primary' : 'ghost'}
+                    {...(isExternal(link.href)
+                      ? { target: '_blank', rel: 'noopener noreferrer' }
+                      : {})}
+                  >
+                    {link.label}
+                  </Button>
+                ))}
+              </div>
+            ) : (
+              <Button
+                size="sm"
+                href={current.href}
+                className="featured__cta"
+                {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+              >
+                {current.ctaLabel ?? 'View repository'}
+              </Button>
+            )}
           </div>
         </div>
       </div>

--- a/src/data/portfolio.js
+++ b/src/data/portfolio.js
@@ -5,7 +5,8 @@
  * shipped in /public/assets so we reuse the same source art.
  */
 
-/** @typedef {{ title: string, date: string, description: string, image?: string, imageContain?: boolean, slug?: string, tags: string[], href: string, featured?: boolean, hideFromGallery?: boolean, ctaLabel?: string }} Project */
+/** @typedef {{ label: string, href: string }} ProjectLink */
+/** @typedef {{ title: string, date: string, description: string, image?: string, imageContain?: boolean, slug?: string, tags: string[], href: string, featured?: boolean, hideFromGallery?: boolean, ctaLabel?: string, links?: ProjectLink[] }} Project */
 
 /** @type {Project[]} */
 export const projects = [
@@ -111,6 +112,13 @@ export const projects = [
     tags: ['Python', 'ETL/ELT', 'Data Pipelines'],
     href: 'https://waga-dashboard.pages.dev',
     featured: true,
+    links: [
+      { label: 'View Dashboard', href: 'https://waga-dashboard.pages.dev' },
+      {
+        label: 'View Repository',
+        href: 'https://github.com/cdcoonce/Weather-Adjusted-Generation-Analytics',
+      },
+    ],
   },
   {
     title: 'Ames Housing Model Comparison',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -411,6 +411,13 @@ a {
   margin-top: var(--space-2);
 }
 
+.featured__cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: var(--space-2);
+}
+
 @media (min-width: 620px) {
   .metrics {
     grid-template-columns: repeat(4, 1fr);


### PR DESCRIPTION
Adds two CTA buttons to the featured **Weather-Adjusted Generation Analytics** card: **View Dashboard** (primary → live Cloudflare dashboard) and **View Repository** (ghost → GitHub repo), replacing the single card CTA.

## Changes
- `src/data/portfolio.js` — new optional `links: {label, href}[]` on the `Project` model; WAGA card gets the two links.
- `src/components/tabs/Overview.jsx` — featured card renders one `<Button>` per `links` entry (first `primary`, rest `ghost`) inside a `.featured__cta-group`; falls back to the existing single-CTA path when `links` is absent, so **other featured cards are unaffected**.
- `src/styles/global.css` — `.featured__cta-group` flex row (wrap, 0.5rem gap).
- `__tests__/portfolio-featured.test.js` — locks the WAGA card's two links + absolute-URL invariant.

## Verification
- Local CI gate: `npm test` **28/28** ✓ · `npm run lint` (css+js) ✓ · `npm run build` ✓
- Ran the dev server and drove the carousel to the WAGA slide; confirmed both buttons render with correct labels, hrefs (`waga-dashboard.pages.dev` / GitHub repo), `target=_blank`, primary/ghost variants, flex layout.

Targets `dev` for final check before promotion to `main`.