### PR TITLE
style(work): uniform black WAGA card buttons

### DIFF
--- a/src/components/tabs/Overview.jsx
+++ b/src/components/tabs/Overview.jsx
@@ -78,12 +78,11 @@ export default function Overview() {
             </div>
             {current.links?.length ? (
               <div className="featured__cta-group">
-                {current.links.map((link, i) => (
+                {current.links.map((link) => (
                   <Button
                     key={link.href}
                     size="sm"
                     href={link.href}
-                    variant={i === 0 ? 'primary' : 'ghost'}
                     {...(isExternal(link.href)
                       ? { target: '_blank', rel: 'noopener noreferrer' }
                       : {})}


### PR DESCRIPTION
Both CTA buttons on the featured WAGA card now use the same black (`btn--primary`) fill — dropped the `ghost` variant on the second button so **View Dashboard** and **View Repository** read as equal-weight actions.

- `src/components/tabs/Overview.jsx` — remove the first-vs-rest variant split; all `links` buttons fall through to `Button`'s default `primary` variant.

## Verification
- Local gate: `npm test` 28/28 ✓ · lint ✓ · build ✓
- Live DOM check on the WAGA slide: both buttons `rgb(53,53,53)` background / white text, identical.

Targets `dev` for final check before `main`.