### PR TITLE
Promote WAGA card updates to production

### DIFF
--- a/__tests__/portfolio-featured.test.js
+++ b/__tests__/portfolio-featured.test.js
@@ -19,3 +19,24 @@ describe('featuredProjects', () => {
     expect(featuredProjects(sample)).toEqual([{ featured: true }]);
   });
 });
+
+describe('WAGA card links', () => {
+  const waga = projects.find((p) => p.slug === 'waga');
+
+  test('exposes both a Dashboard and a Repository link', () => {
+    expect(waga).toBeDefined();
+    expect(waga.links).toEqual([
+      { label: 'View Dashboard', href: 'https://waga-dashboard.pages.dev' },
+      {
+        label: 'View Repository',
+        href: 'https://github.com/cdcoonce/Weather-Adjusted-Generation-Analytics',
+      },
+    ]);
+  });
+
+  test('every link is an absolute URL', () => {
+    for (const link of waga.links) {
+      expect(link.href).toMatch(/^https?:\/\//);
+    }
+  });
+});

--- a/src/components/tabs/Overview.jsx
+++ b/src/components/tabs/Overview.jsx
@@ -76,14 +76,32 @@ export default function Overview() {
                 <Tag key={t}>{t}</Tag>
               ))}
             </div>
-            <Button
-              size="sm"
-              href={current.href}
-              className="featured__cta"
-              {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-            >
-              {current.ctaLabel ?? 'View repository'}
-            </Button>
+            {current.links?.length ? (
+              <div className="featured__cta-group">
+                {current.links.map((link, i) => (
+                  <Button
+                    key={link.href}
+                    size="sm"
+                    href={link.href}
+                    variant={i === 0 ? 'primary' : 'ghost'}
+                    {...(isExternal(link.href)
+                      ? { target: '_blank', rel: 'noopener noreferrer' }
+                      : {})}
+                  >
+                    {link.label}
+                  </Button>
+                ))}
+              </div>
+            ) : (
+              <Button
+                size="sm"
+                href={current.href}
+                className="featured__cta"
+                {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+              >
+                {current.ctaLabel ?? 'View repository'}
+              </Button>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/tabs/Overview.jsx
+++ b/src/components/tabs/Overview.jsx
@@ -78,12 +78,11 @@ export default function Overview() {
             </div>
             {current.links?.length ? (
               <div className="featured__cta-group">
-                {current.links.map((link, i) => (
+                {current.links.map((link) => (
                   <Button
                     key={link.href}
                     size="sm"
                     href={link.href}
-                    variant={i === 0 ? 'primary' : 'ghost'}
                     {...(isExternal(link.href)
                       ? { target: '_blank', rel: 'noopener noreferrer' }
                       : {})}

--- a/src/data/portfolio.js
+++ b/src/data/portfolio.js
@@ -5,7 +5,8 @@
  * shipped in /public/assets so we reuse the same source art.
  */
 
-/** @typedef {{ title: string, date: string, description: string, image?: string, imageContain?: boolean, slug?: string, tags: string[], href: string, featured?: boolean, hideFromGallery?: boolean, ctaLabel?: string }} Project */
+/** @typedef {{ label: string, href: string }} ProjectLink */
+/** @typedef {{ title: string, date: string, description: string, image?: string, imageContain?: boolean, slug?: string, tags: string[], href: string, featured?: boolean, hideFromGallery?: boolean, ctaLabel?: string, links?: ProjectLink[] }} Project */
 
 /** @type {Project[]} */
 export const projects = [
@@ -111,6 +112,13 @@ export const projects = [
     tags: ['Python', 'ETL/ELT', 'Data Pipelines'],
     href: 'https://waga-dashboard.pages.dev',
     featured: true,
+    links: [
+      { label: 'View Dashboard', href: 'https://waga-dashboard.pages.dev' },
+      {
+        label: 'View Repository',
+        href: 'https://github.com/cdcoonce/Weather-Adjusted-Generation-Analytics',
+      },
+    ],
   },
   {
     title: 'Ames Housing Model Comparison',

--- a/src/data/portfolio.js
+++ b/src/data/portfolio.js
@@ -109,7 +109,7 @@ export const projects = [
       'A production-grade ELT pipeline for weather-normalized renewable-asset performance — dlt ingestion into Snowflake, dbt transformations through a semantic layer, and Polars analytics, all orchestrated by Dagster.',
     slug: 'waga',
     tags: ['Python', 'ETL/ELT', 'Data Pipelines'],
-    href: 'https://github.com/cdcoonce/Weather-Adjusted-Generation-Analytics',
+    href: 'https://waga-dashboard.pages.dev',
     featured: true,
   },
   {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -411,6 +411,13 @@ a {
   margin-top: var(--space-2);
 }
 
+.featured__cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: var(--space-2);
+}
+
 @media (min-width: 620px) {
   .metrics {
     grid-template-columns: repeat(4, 1fr);


### PR DESCRIPTION
Promote `dev` → `main`. Ships the featured **Weather-Adjusted Generation Analytics** card updates to charleslikesdata.com.

## Commits
- `3d98b88` point WAGA card to live dashboard
- `1318e53` dual **View Dashboard** / **View Repository** buttons
- `6f786eb` uniform black fill on both buttons

## Verification
Local gate green on each change (`npm test` 28/28 · lint · build) and live-server DOM checks confirmed both buttons render with correct labels, hrefs (`waga-dashboard.pages.dev` / GitHub repo), `target=_blank`, and matching black fill. Charles reviewed on `dev`.