### PR TITLE
chore(gallery): refresh WAGA card for the mixed-fleet dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-07-06
+
+### Changed
+- Refreshed the Weather-Adjusted Generation Analytics project card to reflect
+  the mixed-technology fleet (wind, solar, battery, gas) driven by real hourly
+  Open-Meteo weather: updated description, on-card metrics (4 technologies /
+  12 assets / 3 contracted marts / capacity-by-technology), and added the
+  "Analytics Dashboards" tag.
+
 ## [2.1.0] - 2026-07-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [2.1.1] - 2026-07-06
 
 ### Changed
+
 - Refreshed the Weather-Adjusted Generation Analytics project card to reflect
   the mixed-technology fleet (wind, solar, battery, gas) driven by real hourly
   Open-Meteo weather: updated description, on-card metrics (4 technologies /

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfoliowebsite",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Welcome to the repository for my personal portfolio site: [**charleslikesdata.com**](https://charleslikesdata.com)",
   "main": "index.html",
   "scripts": {

--- a/src/data/metrics.json
+++ b/src/data/metrics.json
@@ -85,13 +85,7 @@
       {
         "type": "chips",
         "title": "PROJECT PRESETS",
-        "items": [
-          "analysis",
-          "claude-tooling",
-          "data-pipeline",
-          "full-stack",
-          "python-api"
-        ]
+        "items": ["analysis", "claude-tooling", "data-pipeline", "full-stack", "python-api"]
       },
       {
         "type": "chips",
@@ -151,11 +145,7 @@
       },
       {
         "type": "chips",
-        "items": [
-          "Daily · incremental",
-          "Weekly report",
-          "Monthly report"
-        ]
+        "items": ["Daily · incremental", "Weekly report", "Monthly report"]
       }
     ]
   },
@@ -208,11 +198,7 @@
       },
       {
         "type": "chips",
-        "items": [
-          "Open-Meteo ERA5 weather",
-          "dbt contracts",
-          "Polars physics engine"
-        ]
+        "items": ["Open-Meteo ERA5 weather", "dbt contracts", "Polars physics engine"]
       }
     ]
   },

--- a/src/data/metrics.json
+++ b/src/data/metrics.json
@@ -160,54 +160,58 @@
     ]
   },
   "waga": {
-    "eyebrow": "WEATHER-ADJUSTED GENERATION · ELT",
+    "eyebrow": "MIXED-FLEET GENERATION · ELT",
     "pill": "Snowflake",
-    "headline": "Renewable output, weather-normalized",
-    "subtitle": "dlt ingestion into Snowflake, transformed with dbt through a semantic layer, orchestrated by Dagster.",
+    "headline": "Wind, solar, battery & gas — weather-driven",
+    "subtitle": "Real hourly Open-Meteo weather drives a physics-based fleet; dlt into Snowflake, contracted dbt marts, orchestrated by Dagster.",
     "tiles": [
       {
-        "value": "2",
-        "label": "dlt sources"
-      },
-      {
-        "value": "8",
-        "label": "dbt models",
+        "value": "4",
+        "label": "technologies",
         "accent": true
       },
       {
-        "value": "2",
-        "label": "Perf marts"
+        "value": "12",
+        "label": "fleet assets"
       },
       {
-        "value": "4",
-        "label": "Test modules"
+        "value": "3",
+        "label": "contracted marts"
+      },
+      {
+        "value": "146",
+        "label": "unit tests"
       }
     ],
     "blocks": [
       {
         "type": "bars",
-        "title": "PIPELINE STAGES",
+        "title": "CAPACITY BY TECHNOLOGY (MW)",
         "items": [
           {
-            "label": "Extract · dlt sources",
-            "value": 2
+            "label": "Wind",
+            "value": 450
           },
           {
-            "label": "Transform · dbt models",
-            "value": 8
+            "label": "Solar",
+            "value": 270
           },
           {
-            "label": "Marts · perf tables",
-            "value": 2
+            "label": "Gas",
+            "value": 290
+          },
+          {
+            "label": "Battery",
+            "value": 160
           }
         ]
       },
       {
         "type": "chips",
         "items": [
-          "Snowflake warehouse",
-          "dbt semantic layer",
-          "Polars analytics"
+          "Open-Meteo ERA5 weather",
+          "dbt contracts",
+          "Polars physics engine"
         ]
       }
     ]

--- a/src/data/portfolio.js
+++ b/src/data/portfolio.js
@@ -105,11 +105,11 @@ export const projects = [
   },
   {
     title: 'Weather-Adjusted Generation Analytics',
-    date: 'May 2026',
+    date: 'Jul 2026',
     description:
-      'A production-grade ELT pipeline for weather-normalized renewable-asset performance — dlt ingestion into Snowflake, dbt transformations through a semantic layer, and Polars analytics, all orchestrated by Dagster.',
+      'A weather-driven ELT pipeline for a mixed generation fleet — wind, solar, battery, and gas — fed by real hourly Open-Meteo weather, with dlt ingestion into Snowflake, contracted dbt marts, and a Polars physics engine, all orchestrated by Dagster.',
     slug: 'waga',
-    tags: ['Python', 'ETL/ELT', 'Data Pipelines'],
+    tags: ['Python', 'ETL/ELT', 'Data Pipelines', 'Analytics Dashboards'],
     href: 'https://waga-dashboard.pages.dev',
     featured: true,
     links: [


### PR DESCRIPTION
Refreshes the **Weather-Adjusted Generation Analytics** project card to match the updated dashboard (now live at [waga-dashboard.pages.dev](https://waga-dashboard.pages.dev)).

The dashboard now models a mixed generation fleet — **wind, solar, battery, gas** — driven by **real hourly Open-Meteo weather**, through contracted dbt marts, with the afk-cockpit-matched palette.

### Changes
- **Description** → mixed generation fleet + real weather + contracted marts (was "renewable-asset performance")
- **On-card metrics** (`metrics.json`) → 4 technologies / 12 fleet assets / 3 contracted marts / 146 unit tests, and a *capacity-by-technology* bar block (was generic pipeline-stage counts)
- **Tag** → added `Analytics Dashboards` (the project now has a rich interactive dashboard)
- **Date** → May → Jul 2026
- Version 2.1.0 → **2.1.1**; CHANGELOG updated

`npm run build` + `npm run lint` clean; card content verified rendering in the dev preview. PATCH (content update).