### PR TITLE
chore(metrics): add WAGA collector so its card KPIs auto-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [2.1.2] - 2026-07-06
 
 ### Added
+
 - `collect_waga` collector in `scripts/collect-metrics.py` so the
   Weather-Adjusted Generation Analytics card's KPIs auto-recompute from the
   WAGA repo (technologies + fleet-asset count and capacity-by-technology from
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   instead of being hand-maintained.
 
 ### Changed
+
 - Relabel the WAGA "unit tests" tile to "tests" (156 total `def test_`, the
   statically-computable count the collector reports).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.1.2] - 2026-07-06
+
+### Added
+- `collect_waga` collector in `scripts/collect-metrics.py` so the
+  Weather-Adjusted Generation Analytics card's KPIs auto-recompute from the
+  WAGA repo (technologies + fleet-asset count and capacity-by-technology from
+  `fleet.py`, contracted-mart count from `marts.yml`, test count from `tests/`)
+  instead of being hand-maintained.
+
+### Changed
+- Relabel the WAGA "unit tests" tile to "tests" (156 total `def test_`, the
+  statically-computable count the collector reports).
+
 ## [2.1.1] - 2026-07-06
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfoliowebsite",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Welcome to the repository for my personal portfolio site: [**charleslikesdata.com**](https://charleslikesdata.com)",
   "main": "index.html",
   "scripts": {

--- a/scripts/collect-metrics.py
+++ b/scripts/collect-metrics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Recompute the featured-card KPIs in src/data/metrics.json from source repos.
 
-All four project sources live locally on this Mac (including the private ones),
+All the project sources live locally on this Mac (including the private ones),
 so this is the only place every number is computable. The script rewrites the
 numeric values and the preset/persona lists while preserving the hand-written
 copy (eyebrows, headlines, subtitles, tile/bar labels) and the card structure.
@@ -31,6 +31,7 @@ GITHUB = Path.home() / "Developer" / "GitHub"
 VAULT = GITHUB / "my-brain"
 CW = GITHUB / "claude-workflow"
 OURA = GITHUB / "oura-pipeline"
+WAGA = GITHUB / "Weather_Adjusted_Generation_Analytics"
 PORTFOLIO = GITHUB / "PortfolioWebsite"
 AFK_HTML = PORTFOLIO / "public" / "afk-cockpit" / "index.html"
 METRICS = PORTFOLIO / "src" / "data" / "metrics.json"
@@ -169,6 +170,44 @@ def collect_oura(proj: dict, changes: list) -> None:
         set_bar(bars, "Marts · fact tables", marts, changes, "oura/marts")
 
 
+def collect_waga(proj: dict, changes: list) -> None:
+    fleet_src = (WAGA / "src" / "weather_analytics" / "mock_data" / "fleet.py").read_text(
+        encoding="utf-8", errors="ignore"
+    )
+    # FLEET factory calls, e.g. `_wind("ASSET_001", "Roscoe Ridge", 150.0, ...)`.
+    # The leading string arg distinguishes the calls from the `def _wind(...)`
+    # factory definitions (whose first arg is a bare identifier).
+    calls = re.findall(
+        r'_(wind|solar|battery|gas)\(\s*"[^"]+",\s*"[^"]+",\s*([\d.]+)', fleet_src
+    )
+    cap_by_type: dict[str, float] = {}
+    for kind, capacity_mw in calls:
+        cap_by_type[kind] = cap_by_type.get(kind, 0.0) + float(capacity_mw)
+
+    marts_yml = (
+        WAGA / "dbt" / "renewable_dbt" / "models" / "marts" / "marts.yml"
+    ).read_text(encoding="utf-8", errors="ignore")
+    contracted = len(re.findall(r"enforced:\s*true", marts_yml))
+    tests = sum(
+        len(re.findall(r"def test_", p.read_text(encoding="utf-8", errors="ignore")))
+        for p in (WAGA / "tests").rglob("*.py")
+    )
+
+    set_tile(proj, "technologies", str(len(cap_by_type)), changes, "waga technologies")
+    set_tile(proj, "fleet assets", str(len(calls)), changes, "waga fleet-assets")
+    set_tile(proj, "contracted marts", str(contracted), changes, "waga contracted-marts")
+    set_tile(proj, "tests", str(tests), changes, "waga tests")
+
+    bars = block(proj, "bars", "CAPACITY BY TECHNOLOGY (MW)")
+    if bars:
+        for item in bars["items"]:
+            kind = item["label"].lower()
+            if kind in cap_by_type:
+                set_bar(bars, item["label"], round(cap_by_type[kind]), changes, f"waga/{kind}")
+            else:
+                log.warning("  waga technology %r not matched — keeping existing", item["label"])
+
+
 def collect_afk(proj: dict, changes: list) -> None:
     html = AFK_HTML.read_text(encoding="utf-8", errors="ignore")
 
@@ -229,6 +268,7 @@ COLLECTORS = {
     "afk": collect_afk,
     "claude-workflow": collect_claude_workflow,
     "oura": collect_oura,
+    "waga": collect_waga,
     "my-brain": collect_my_brain,
 }
 

--- a/src/data/metrics.json
+++ b/src/data/metrics.json
@@ -169,8 +169,8 @@
         "label": "contracted marts"
       },
       {
-        "value": "146",
-        "label": "unit tests"
+        "value": "156",
+        "label": "tests"
       }
     ],
     "blocks": [


### PR DESCRIPTION
Follow-up to #132. The WAGA card was hand-maintained; this makes it self-updating like the other featured cards.

Adds `collect_waga()` to `scripts/collect-metrics.py` that recomputes the card from the WAGA repo:
- **technologies** + **fleet assets** and the **capacity-by-technology** bars from `fleet.py` (parses the `FLEET` factory calls)
- **contracted marts** from `marts.yml` (`enforced: true` count)
- **tests** from `tests/` (`def test_` count)

Dry-run shows **no WAGA delta** — the collector computes exactly the current hand-set values (4 / 12 / 3 / 156, caps 450·270·290·160).

Also relabels the "unit tests" tile → "tests" (156 is the total `def test_` count the collector reports; `pytest -m unit` runs 146). Bump 2.1.1 → 2.1.2; changelog updated. Prettier + lint clean.

> Note: the dry-run also surfaced unrelated pre-existing drift in the afk card (merged 498→499 etc.) from the cockpit snapshot — not touched here.