### PR TITLE
test(wiki): make changelog feat/fix tests deterministic

### DIFF
--- a/scripts/wiki/generate_changelog.py
+++ b/scripts/wiki/generate_changelog.py
@@ -104,23 +104,31 @@ def _fetch_git_log(repo_root: Path, max_commits: int = 50) -> list[dict]:
     return commits
 
 
-def generate(repo_root: Path) -> str:
+def generate(repo_root: Path, commits: list[dict] | None = None) -> str:
     """Generate Changelog.md content block for the wiki.
 
-    Calls git log, parses conventional commit messages, groups by type,
-    and returns a Markdown changelog showing the last 50 commits.
+    Parses conventional commit records, groups them by type, and returns a
+    Markdown changelog. When ``commits`` is not supplied, the last 50 commits
+    are read from ``git log``; passing an explicit list lets callers (and
+    tests) exercise the grouping/rendering logic deterministically without
+    depending on live repository history.
 
     Parameters
     ----------
     repo_root : Path
         Absolute path to the repository root.
+    commits : list[dict] | None, optional
+        Pre-built commit records (keys: ``sha``, ``subject``, ``body``,
+        ``author``, ``date``, ``type``). Defaults to ``None``, which fetches
+        the last 50 commits from ``git log``.
 
     Returns
     -------
     str
         Markdown string suitable for insertion into the generated block.
     """
-    commits = _fetch_git_log(repo_root, max_commits=50)
+    if commits is None:
+        commits = _fetch_git_log(repo_root, max_commits=50)
     lines: list[str] = []
 
     if not commits:

--- a/tests/test_wiki_phase2.py
+++ b/tests/test_wiki_phase2.py
@@ -325,14 +325,46 @@ class TestGenerateChangelog:
         )
 
     def test_has_feat_commits(self):
-        """Output contains feat section (repo has feat commits)."""
-        output = generate_changelog.generate(REPO_ROOT)
-        assert "Features" in output
+        """A feat commit is rendered under the Features section.
+
+        Drives the generator with a synthetic commit list so the grouping
+        logic is asserted deterministically, independent of the live 50-commit
+        git window (which may contain only chore/content commits).
+        """
+        commits = [
+            {
+                "sha": "abc12345",
+                "subject": "feat(carousel): add keyboard navigation",
+                "body": "add keyboard navigation",
+                "author": "Test Author",
+                "date": "2026-01-01",
+                "type": "feat",
+            }
+        ]
+        output = generate_changelog.generate(REPO_ROOT, commits=commits)
+        assert "### Features" in output
+        assert "add keyboard navigation" in output
 
     def test_has_fix_commits(self):
-        """Output contains fix section (repo has fix commits)."""
-        output = generate_changelog.generate(REPO_ROOT)
-        assert "Bug Fixes" in output
+        """A fix commit is rendered under the Bug Fixes section.
+
+        Drives the generator with a synthetic commit list so the grouping
+        logic is asserted deterministically, independent of the live 50-commit
+        git window (which may contain only chore/content commits).
+        """
+        commits = [
+            {
+                "sha": "def67890",
+                "subject": "fix(chat): handle empty response payload",
+                "body": "handle empty response payload",
+                "author": "Test Author",
+                "date": "2026-01-02",
+                "type": "fix",
+            }
+        ]
+        output = generate_changelog.generate(REPO_ROOT, commits=commits)
+        assert "### Bug Fixes" in output
+        assert "handle empty response payload" in output
 
     def test_has_dates(self):
         """Output contains ISO date strings."""


### PR DESCRIPTION
## What

Two `TestGenerateChangelog` tests fail on `main` independent of any recent change:

- `tests/test_wiki_phase2.py::TestGenerateChangelog::test_has_feat_commits`
- `tests/test_wiki_phase2.py::TestGenerateChangelog::test_has_fix_commits`

## Root cause

`generate_changelog.generate()` groups the last 50 git commits by conventional-commit type and emits `### Features` / `### Bug Fixes` sections only when such commits exist. The current 50-commit window holds only chore/content commits (afk-cockpit snapshot auto-commits + content updates), so those sections are never rendered and the two assertions fail. History-dependent brittleness, not a generator bug.

## Fix

Add an optional `commits` param to `generate()` (dependency injection). Default `None` preserves the live `git log` path; the two tests now inject synthetic feat/fix commit records and assert the grouping/rendering deterministically. Other `TestGenerateChangelog` tests still exercise live history and stay green.

Local: `uv run pytest tests/test_wiki_phase2.py` → **45 passed**.

Note: CI's Python step runs only `-m "e2e or validation or a11y"`, so these unit tests aren't executed in CI; verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)