### PR TITLE
feat: lead homepage with evidence, single title, mobile fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-07-18
+
+### Changed
+
+- Overview now leads with the featured-project spotlight (evidence-grade cockpit
+  metrics) instead of the at-a-glance stat tiles. Removed the `20+ / 5+ / 18 /
+1.8M+` vanity metric strip and its `metrics` data export so the default view
+  opens on demonstrated proof (e.g. AFK's 498 merged PRs, $3.58 / PR).
+- Compressed the mobile profile hero — smaller avatar, `clamp()`-scaled name,
+  tighter spacing — so navigation and project proof surface without a
+  full-screen scroll.
+
+### Added
+
+- "See all N projects" call-to-action on the Overview tab that routes into the
+  Work grid, wiring the previously-unused `onSeeWork` handoff.
+- Right-edge fade affordance on the mobile tab bar so the horizontally
+  scrollable tabs (Ask AI, Contact) are no longer silently clipped off-screen.
+
 ## [2.1.2] - 2026-07-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Compressed the mobile profile hero — smaller avatar, `clamp()`-scaled name,
   tighter spacing — so navigation and project proof surface without a
   full-screen scroll.
+- Collapsed the hero role to a single `Analytics Engineer @ Clearway Energy`
+  title (was `Analyst · Analytics Engineer · Solutions Architect`) so the
+  headline matches the data/analytics-engineering work the Work grid proves.
+  The Experience-tab timeline keeps the full factual role.
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfoliowebsite",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Welcome to the repository for my personal portfolio site: [**charleslikesdata.com**](https://charleslikesdata.com)",
   "main": "index.html",
   "scripts": {

--- a/src/components/Portfolio.jsx
+++ b/src/components/Portfolio.jsx
@@ -27,9 +27,7 @@ export default function Portfolio() {
         <div className="profile__text">
           <p className="profile__hello">Hello, I&rsquo;m</p>
           <h1 className="profile__name">Charles Coonce</h1>
-          <p className="profile__role">
-            Analyst · Analytics Engineer · Solutions Architect @ Clearway Energy
-          </p>
+          <p className="profile__role">Analytics Engineer @ Clearway Energy</p>
           <p className="profile__bio">
             I build scalable data pipelines, turn raw data into clear visual insights, and help
             teams make informed decisions.

--- a/src/components/tabs/Overview.jsx
+++ b/src/components/tabs/Overview.jsx
@@ -2,14 +2,19 @@ import { useState } from 'react';
 import Button from '../Button.jsx';
 import Tag from '../Tag.jsx';
 import Cockpit from '../Cockpit.jsx';
-import { metrics, projects } from '../../data/portfolio.js';
+import { projects } from '../../data/portfolio.js';
 import { featuredProjects } from '../../lib/featured.js';
 import { nextIndex, prevIndex } from '../../lib/carousel.js';
 
 const isExternal = (href) => /^https?:\/\//.test(href || '');
+const galleryCount = projects.filter((p) => !p.hideFromGallery).length;
 
-/** Overview tab: at-a-glance metrics + a rotating featured-project spotlight. */
-export default function Overview() {
+/**
+ * Overview tab: leads with a rotating featured-project spotlight (evidence-grade
+ * cockpit metrics), then a CTA into the full Work grid.
+ * @param {{ onSeeWork?: () => void }} props
+ */
+export default function Overview({ onSeeWork }) {
   const featured = featuredProjects(projects);
   const [index, setIndex] = useState(0);
   const current = featured[index] ?? projects[0];
@@ -18,15 +23,6 @@ export default function Overview() {
 
   return (
     <div className="overview" data-testid="overview">
-      <div className="metrics" data-testid="metrics">
-        {metrics.map((m) => (
-          <div className="metric" key={m.label} data-testid="metric">
-            <div className="metric__value">{m.value}</div>
-            <div className="metric__label">{m.label}</div>
-          </div>
-        ))}
-      </div>
-
       <div>
         <div className="featured-head">
           <div className="eyebrow">Featured project</div>
@@ -103,6 +99,17 @@ export default function Overview() {
             )}
           </div>
         </div>
+      </div>
+
+      <div className="overview__more">
+        <Button
+          variant="ghost"
+          onClick={onSeeWork}
+          className="overview__see-work"
+          data-testid="overview-see-work"
+        >
+          See all {galleryCount} projects &rarr;
+        </Button>
       </div>
     </div>
   );

--- a/src/data/portfolio.js
+++ b/src/data/portfolio.js
@@ -295,13 +295,6 @@ export const skills = [
   },
 ];
 
-export const metrics = [
-  { value: '20+', label: 'Projects shipped' },
-  { value: '5+', label: 'Data pipelines built' },
-  { value: '18', label: 'Languages & tools' },
-  { value: '1.8M+', label: 'Records processed' },
-];
-
 export const contactMethods = [
   { label: 'Email', value: 'CharlesCoonce@Gmail.com', href: 'mailto:CharlesCoonce@Gmail.com' },
   {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -43,8 +43,8 @@ a {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: var(--space-12);
-  padding: var(--space-16) var(--space-4) var(--space-8);
+  gap: var(--space-6);
+  padding: var(--space-8) var(--space-4) var(--space-6);
   flex-wrap: wrap;
   text-align: center;
 }
@@ -57,8 +57,8 @@ a {
 }
 
 .profile__avatar {
-  width: 156px;
-  height: 156px;
+  width: 116px;
+  height: 116px;
   border-radius: var(--radius-round);
   object-fit: cover;
 }
@@ -75,7 +75,7 @@ a {
 }
 
 .profile__name {
-  font-size: 2.75rem;
+  font-size: clamp(2rem, 7vw, 2.75rem);
   font-weight: var(--weight-semibold);
   color: var(--text-heading);
   margin: 0.1rem 0 0.4rem;
@@ -126,7 +126,14 @@ a {
 
 @media (min-width: 700px) {
   .profile {
+    gap: var(--space-12);
+    padding: var(--space-16) var(--space-4) var(--space-8);
     text-align: left;
+  }
+
+  .profile__avatar {
+    width: 156px;
+    height: 156px;
   }
 
   .profile__actions {
@@ -223,6 +230,10 @@ a {
   border-bottom: 1px solid var(--border-hairline);
   overflow-x: auto;
   scrollbar-width: none;
+
+  /* Right-edge fade signals the tab row scrolls on narrow screens, so Ask AI
+     and Contact aren't silently clipped off-screen. Removed once tabs fit. */
+  mask-image: linear-gradient(to right, #000 84%, transparent);
 }
 
 .tabbar::-webkit-scrollbar {
@@ -260,6 +271,7 @@ a {
   .tabbar {
     justify-content: center;
     gap: 2.25rem;
+    mask-image: none;
   }
 }
 
@@ -296,30 +308,9 @@ a {
   gap: var(--space-8);
 }
 
-.metrics {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: var(--space-4);
-}
-
-.metric {
-  background: var(--surface-muted);
-  border-radius: var(--radius-card);
-  padding: 1.4rem 1.5rem;
-  text-align: center;
-}
-
-.metric__value {
-  font-size: 2rem;
-  font-weight: var(--weight-semibold);
-  color: var(--text-heading);
-  line-height: 1;
-}
-
-.metric__label {
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-  margin-top: 0.35rem;
+.overview__more {
+  display: flex;
+  justify-content: center;
 }
 
 .featured-head {
@@ -416,12 +407,6 @@ a {
   flex-wrap: wrap;
   gap: 0.5rem;
   margin-top: var(--space-2);
-}
-
-@media (min-width: 620px) {
-  .metrics {
-    grid-template-columns: repeat(4, 1fr);
-  }
 }
 
 @media (min-width: 800px) {

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -23,7 +23,6 @@ NAV_LABELS = ["Overview", "Work", "Experience", "Testimonials", "Ask AI", "Conta
 GALLERY_COUNT = 22
 # WORK_FILTERS = "all" + 7 categories.
 WORK_FILTER_COUNT = 8
-METRIC_COUNT = 4
 SKILL_CATEGORY_COUNT = 4
 EXPERIENCE_ROW_COUNT = 3
 CONTACT_CARD_COUNT = 4

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -1,23 +1,17 @@
-"""Overview tab: metrics grid + featured-project spotlight carousel.
+"""Overview tab: featured-project spotlight carousel + see-all-work CTA.
 
 The Overview panel is the active tab on load (no switch needed), rendered as
-static HTML that Astro then hydrates. It shows a fixed grid of metric tiles and
-a rotating spotlight whose current slide is either a Cockpit <svg> or an <img>.
-Project titles are intentionally not hard-asserted — the data may reorder — so
-these tests exercise structure, counts, and carousel wiring instead.
+static HTML that Astro then hydrates. It leads with a rotating spotlight whose
+current slide is either a Cockpit <svg> or an <img>, then a CTA into the Work
+grid. Project titles are intentionally not hard-asserted — the data may reorder
+— so these tests exercise structure, counts, and carousel wiring instead.
 """
 
 import pytest
 
-from helpers import FEATURED_COUNT, METRIC_COUNT, switch_tab
+from helpers import FEATURED_COUNT, switch_tab
 
 pytestmark = pytest.mark.e2e
-
-
-def test_metrics_grid_present(page):
-    metrics = page.locator('[data-testid="metrics"]')
-    assert metrics.is_visible()
-    assert page.locator('[data-testid="metric"]').count() == METRIC_COUNT
 
 
 def test_featured_spotlight_renders(page):
@@ -65,5 +59,13 @@ def test_returning_to_overview_still_renders(page):
     # Overview unmounts when another tab is active; switching back re-mounts it.
     switch_tab(page, "work")
     switch_tab(page, "overview")
-    assert page.locator('[data-testid="metrics"]').is_visible()
     assert page.locator('[data-testid="featured"]').is_visible()
+
+
+def test_see_all_work_cta_switches_to_work(page):
+    # The Overview CTA is the promoted path into the full project grid.
+    cta = page.locator('[data-testid="overview-see-work"]')
+    assert cta.is_visible()
+    cta.click()
+    assert page.locator('[data-testid="work"]').is_visible()
+    assert page.locator('[data-testid="overview"]').count() == 0


### PR DESCRIPTION
## Summary

Homepage fixes from a hiring-manager-lens design review. Every change targets the
~20-second skim that decides "senior conversation or not" — leading with
demonstrated proof instead of generic claims.

### Changed

- **Overview leads with evidence.** Removed the `20+ / 5+ / 18 / 1.8M+` vanity stat
  strip (and its `metrics` data export); the default view now opens on the AFK
  cockpit (498 merged PRs, $3.58 / PR).
- **Single hero title.** `Analyst · Analytics Engineer · Solutions Architect` →
  `Analytics Engineer @ Clearway Energy`, so the headline matches the
  data/analytics-engineering work the Work grid proves. The Experience-tab
  timeline keeps the full factual role.
- **Mobile hero compressed** (avatar 156→116, `clamp()`-scaled name, tighter
  spacing) so navigation and project proof surface without a full-screen scroll.

### Added

- **"See all N projects" CTA** on Overview that routes into the Work grid, wiring
  the previously-dead `onSeeWork` handoff.
- **Right-edge fade on the mobile tab bar** so the horizontally scrollable tabs
  (Ask AI, Contact) are no longer silently clipped off-screen. `.tabbar` stays
  `position: sticky` (guarded by `test_tabbar_is_sticky`).

### Not included (deliberate)

- Full tab-collapse redesign — the tabbed SPA is a defensible architecture; the
  CTA is the lighter fix for the buried-grid problem.
- Experience quantification and a senior/technical testimonial — need real inputs,
  tracked separately.
- Ask-AI retrieval ordering (`lambda/` RAG) — separate subsystem, follow-up.

### Verification

Full CI gate green locally: Prettier, Stylelint, ESLint, Jest (56), Astro build,
and the Playwright E2E set (`-m "e2e or validation or a11y"`, 56 passed). Bumps to
v2.2.0.
