### PR TITLE
chore(gallery): rename my-brain featured card to The Vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-07-19
+
+### Changed
+
+- Renamed the second-brain featured project from `my-brain` to **The Vault —
+  Second Brain Knowledge System** (title, slug `the-vault`, and cockpit-card
+  eyebrow) to match the repo/vault rename. The card still links to the public
+  `second-brain` template via its "Use this template" CTA.
+- Pointed the metrics collector (`scripts/collect-metrics.py`) at
+  `~/Developer/GitHub/the-vault` (was `my-brain`) so the auto-refreshed KPI card
+  keeps reading a valid source after the local folder rename.
+
 ## [2.2.0] - 2026-07-18
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfoliowebsite",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Welcome to the repository for my personal portfolio site: [**charleslikesdata.com**](https://charleslikesdata.com)",
   "main": "index.html",
   "scripts": {

--- a/scripts/collect-metrics.py
+++ b/scripts/collect-metrics.py
@@ -28,7 +28,7 @@ from pathlib import Path
 log = logging.getLogger("collect-metrics")
 
 GITHUB = Path.home() / "Developer" / "GitHub"
-VAULT = GITHUB / "my-brain"
+VAULT = GITHUB / "the-vault"
 CW = GITHUB / "claude-workflow"
 OURA = GITHUB / "oura-pipeline"
 WAGA = GITHUB / "Weather_Adjusted_Generation_Analytics"
@@ -107,24 +107,24 @@ def set_bar(blk: dict, label: str, value: int, changes: list, name: str) -> None
 # --------------------------------------------------------------------------- #
 # per-project collectors — each mutates `proj` and appends (name, old, new)
 # --------------------------------------------------------------------------- #
-def collect_my_brain(proj: dict, changes: list) -> None:
+def collect_the_vault(proj: dict, changes: list) -> None:
     notes = count_notes(VAULT)
     wikilinks = sum(len(WIKILINK.findall(p.read_text(encoding="utf-8", errors="ignore")))
                     for p in iter_notes(VAULT))
     skills_hooks = sum(count_files(VAULT / ".claude" / d) for d in ("commands", "agents", "scripts"))
     domains = sum(1 for p in VAULT.iterdir() if p.is_dir() and not p.name.startswith("."))
 
-    set_tile(proj, "Notes", str(notes), changes, "my-brain notes")
-    set_tile(proj, "Wikilinks", fmt_k(wikilinks), changes, "my-brain wikilinks")
-    set_tile(proj, "Skills & hooks", str(skills_hooks), changes, "my-brain skills&hooks")
-    set_tile(proj, "Domains", str(domains), changes, "my-brain domains")
+    set_tile(proj, "Notes", str(notes), changes, "the-vault notes")
+    set_tile(proj, "Wikilinks", fmt_k(wikilinks), changes, "the-vault wikilinks")
+    set_tile(proj, "Skills & hooks", str(skills_hooks), changes, "the-vault skills&hooks")
+    set_tile(proj, "Domains", str(domains), changes, "the-vault domains")
 
     bars = block(proj, "bars", "NOTES BY DOMAIN")
     if bars:
         for item in bars["items"]:
             d = VAULT / item["label"]
             if d.is_dir():
-                set_bar(bars, item["label"], count_notes(d), changes, f"my-brain/{item['label']}")
+                set_bar(bars, item["label"], count_notes(d), changes, f"the-vault/{item['label']}")
 
 
 def collect_claude_workflow(proj: dict, changes: list) -> None:
@@ -269,7 +269,7 @@ COLLECTORS = {
     "claude-workflow": collect_claude_workflow,
     "oura": collect_oura,
     "waga": collect_waga,
-    "my-brain": collect_my_brain,
+    "the-vault": collect_the_vault,
 }
 
 

--- a/scripts/metrics-cron.md
+++ b/scripts/metrics-cron.md
@@ -10,7 +10,7 @@ is recomputed from its source repo by
 | afk             | `./afk-cockpit/index.html`           | header stats, cost tile, per-repo attempts (scraped; repo is private) |
 | claude-workflow | `~/Developer/GitHub/claude-workflow` | skills, presets, `def test_` count, commits, preset/persona lists     |
 | oura            | `~/Developer/GitHub/oura-pipeline`   | API sources, dbt models, schedules, test modules, pipeline stages     |
-| my-brain        | `~/Developer/GitHub/my-brain`        | notes, wikilinks, skills+hooks, domains, notes-by-domain              |
+| the-vault       | `~/Developer/GitHub/the-vault`       | notes, wikilinks, skills+hooks, domains, notes-by-domain              |
 
 Run it by hand anytime:
 

--- a/src/data/metrics.json
+++ b/src/data/metrics.json
@@ -50,7 +50,7 @@
             "value": 48
           },
           {
-            "label": "my-brain",
+            "label": "the-vault",
             "value": 10
           }
         ]
@@ -264,8 +264,8 @@
       }
     ]
   },
-  "my-brain": {
-    "eyebrow": "MY-BRAIN · SECOND BRAIN",
+  "the-vault": {
+    "eyebrow": "THE VAULT · SECOND BRAIN",
     "pill": "Obsidian",
     "headline": "A knowledge graph that thinks with me",
     "subtitle": "Graph-first Obsidian vault + Claude Code automation, auto-synced across 2 machines.",

--- a/src/data/portfolio.js
+++ b/src/data/portfolio.js
@@ -52,11 +52,11 @@ export const projects = [
     featured: true,
   },
   {
-    title: 'my-brain — Second-Brain Knowledge System',
+    title: 'The Vault — Second Brain Knowledge System',
     date: 'Jul 2026',
     description:
       'A graph-first Obsidian vault wired to a Claude Code automation layer — interlinked notes and wikilinks spanning every life domain, auto-committed and synced across two machines by a session hook, with custom skills, agents, and hooks doing the upkeep.',
-    slug: 'my-brain',
+    slug: 'the-vault',
     tags: ['Obsidian', 'AI Tooling'],
     href: 'https://github.com/cdcoonce/second-brain',
     featured: true,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -19,7 +19,7 @@ TAB_ROOT = {
 NAV_KEYS = ["overview", "work", "experience", "testimonials", "ai", "contact"]
 NAV_LABELS = ["Overview", "Work", "Experience", "Testimonials", "Ask AI", "Contact"]
 
-# projects[] minus the single hideFromGallery entry (my-brain).
+# projects[] minus the single hideFromGallery entry (the-vault).
 GALLERY_COUNT = 22
 # WORK_FILTERS = "all" + 7 categories.
 WORK_FILTER_COUNT = 8


### PR DESCRIPTION
Renames the second-brain featured project from `my-brain` to **The Vault — Second Brain Knowledge System**, following the repo/vault rename (`cdcoonce/my-brain` → `cdcoonce/the-vault`).

## Changes
- **portfolio.js** — card title → "The Vault — Second Brain Knowledge System"; slug `my-brain` → `the-vault`. `href` stays on the **public `second-brain` template** (the vault repo is private) via the "Use this template" CTA.
- **metrics.json** — cockpit-card key + eyebrow (`THE VAULT · SECOND BRAIN`) + the AFK per-repo bar label.
- **collect-metrics.py** — source path → `~/Developer/GitHub/the-vault` (the local folder was renamed, so the old path no longer resolves); renamed collector fn / registry key / log labels.
- **metrics-cron.md** doc table + **tests/helpers.py** comment.
- Version `2.2.0` → `2.2.1` + CHANGELOG.

## Verification
- Jest **56/56** pass · `metrics.json` valid JSON · `collect-metrics.py` dry-run reads the renamed folder successfully · browser check confirms the rendered card (eyebrow, title, CTA; no `my-brain` on the page).

## Note
The AFK card's per-repo bar (`the-vault` = 10) matches against afk telemetry that still logs the old repo name; that one value holds (fail-soft) until afk logs `the-vault`.

⚠️ Merging this to `main` deploys to charleslikesdata.com (GitHub Pages).