### PR TITLE
ci: gate validation on real source changes and deploy Pages natively

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -163,7 +163,7 @@ jobs:
         run: uv run pytest tests/ -m "e2e or validation or a11y or ci" -p no:cacheprovider
 
   deploy:
-    name: Deploy to gh-pages
+    name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     needs: [classify, check, e2e]
     # `always()` is REQUIRED: on a snapshot-only push, `check` and `e2e` are
@@ -181,9 +181,17 @@ jobs:
       && needs.e2e.result != 'failure'
       && needs.e2e.result != 'cancelled'
     permissions:
-      contents: write
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v5
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v5
@@ -197,10 +205,37 @@ jobs:
       - name: Build site (Astro)
         run: npm run build
 
-      # Publishes the built dist/ (including CNAME) to the gh-pages branch,
-      # which GitHub Pages serves. Replaces the previous main->gh-pages mirror.
-      - name: Publish dist to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+      # public/CNAME -> dist/CNAME. With Actions-native Pages the custom domain
+      # lives in the repo's Pages settings, but the CNAME file in the artifact
+      # is what the previous branch-based flow relied on and it stays correct
+      # either way. Assert it: losing it silently drops charleslikesdata.com
+      # back to the github.io host, and a portfolio on the wrong domain is a
+      # failure nobody gets paged for.
+      - name: Assert CNAME survived the build
+        run: |
+          set -euo pipefail
+          test -f dist/CNAME
+          echo "dist/CNAME -> $(cat dist/CNAME)"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          path: ./dist
+
+      # Replaces peaceiris/actions-gh-pages -> gh-pages branch -> GitHub's
+      # implicit "pages build and deployment" workflow. That implicit builder
+      # is not defined in this repo, so its poll timeout could not be tuned --
+      # which is how GitHub's Pages deployment lag surfaced here as hard
+      # failures rather than slow successes. Deploying natively removes the
+      # branch hop entirely and makes the timeout a knob we control.
+      #
+      # REQUIRES the repo's Pages source set to "GitHub Actions"
+      # (build_type=workflow). This job fails until that flip happens.
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          # Default is 600000 (10 min). Pages deployment lag is a recurring,
+          # published incident class; wait it out rather than aborting a
+          # deployment that is still in progress.
+          timeout: 1800000

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,10 +9,81 @@ on:
 permissions:
   contents: read
 
+# Never run two deploys of the same ref at once. `cancel-in-progress: false` is
+# deliberate: cancelling a half-published Pages deployment is worse than queuing.
+concurrency:
+  group: ci-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
+  # The afk-cockpit launchd publisher (com.cdcoonce.afk-cockpit-publish, ~every
+  # 31 min) pushes straight to main, rewriting 3 lines of a single generated
+  # file. Running lint + Jest + a full Playwright browser install to validate a
+  # data refresh costs ~48 full pipelines/day and turns every transient GitHub
+  # Actions blip into a red run. Classify the push first; validate only real
+  # source changes. The snapshot still deploys — it has to stay fresh in prod.
+  classify:
+    name: Classify changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.classify.outputs.code_changed }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect whether anything beyond the generated snapshot changed
+        id: classify
+        env:
+          EVENT: ${{ github.event_name }}
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Written verbatim by afk_cockpit/publish.py; nothing else touches it.
+          GENERATED='public/afk-cockpit/index.html'
+
+          emit() {
+            echo "code_changed=$1" >> "$GITHUB_OUTPUT"
+            echo "code_changed=$1"
+          }
+
+          # Fail OPEN. Any push we cannot diff with certainty gets the full
+          # suite; the cost of a wrong guess must be a wasted run, never an
+          # unvalidated deploy.
+          if [ "$EVENT" != 'push' ]; then
+            echo 'Not a push event — running full validation.'; emit true; exit 0
+          fi
+          if [ -z "${BEFORE:-}" ] || [ "$BEFORE" = '0000000000000000000000000000000000000000' ]; then
+            echo 'No usable before-SHA (new branch or force-push) — running full validation.'
+            emit true; exit 0
+          fi
+          if ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "Before-SHA ${BEFORE} unreachable (history rewritten) — running full validation."
+            emit true; exit 0
+          fi
+
+          changed="$(git diff --name-only "$BEFORE" "$SHA" --)"
+          echo 'Changed files:'; printf '%s\n' "$changed" | sed 's/^/  /'
+
+          if [ -z "$changed" ]; then
+            echo 'Empty diff — running full validation.'; emit true; exit 0
+          fi
+
+          other="$(printf '%s\n' "$changed" | grep -Fxv "$GENERATED" || true)"
+          if [ -n "$other" ]; then
+            echo 'Source files changed — running full validation.'; emit true
+          else
+            echo 'Generated snapshot only — skipping lint/test/e2e, deploying directly.'
+            emit false
+          fi
+
   check:
     name: Lint, Test & Build
     runs-on: ubuntu-latest
+    needs: classify
+    if: needs.classify.outputs.code_changed == 'true'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -48,6 +119,8 @@ jobs:
   e2e:
     name: E2E (Playwright)
     runs-on: ubuntu-latest
+    needs: classify
+    if: needs.classify.outputs.code_changed == 'true'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -81,16 +154,32 @@ jobs:
       # DOM/browser suite only: e2e (tab switching, carousels, chat, gallery),
       # validation (built-HTML SEO/semantics), a11y (axe). Excludes `slow`
       # (external link checks + visual snapshots) for deterministic CI runs.
+      # `ci` rides along here rather than in `check`: it needs no browser, but
+      # this job already has uv + deps installed, so it costs nothing extra.
+      # It must be selected explicitly — an unmarked test would never run.
       - name: Run E2E suite against built dist
         env:
           E2E_SKIP_BUILD: '1'
-        run: uv run pytest tests/ -m "e2e or validation or a11y" -p no:cacheprovider
+        run: uv run pytest tests/ -m "e2e or validation or a11y or ci" -p no:cacheprovider
 
   deploy:
     name: Deploy to gh-pages
     runs-on: ubuntu-latest
-    needs: [check, e2e]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [classify, check, e2e]
+    # `always()` is REQUIRED: on a snapshot-only push, `check` and `e2e` are
+    # skipped, and a skipped dependency would otherwise skip `deploy` too. But
+    # `always()` alone would also deploy through a RED suite, so every failure
+    # mode is re-asserted explicitly below. 'skipped' is the only non-success
+    # dependency state allowed through.
+    if: >-
+      always()
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && needs.classify.result == 'success'
+      && needs.check.result != 'failure'
+      && needs.check.result != 'cancelled'
+      && needs.e2e.result != 'failure'
+      && needs.e2e.result != 'cancelled'
     permissions:
       contents: write
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,6 @@ markers = [
     "a11y: accessibility tests",
     "e2e: end-to-end browser tests",
     "validation: HTML/CSS validation tests",
+    "ci: CI/CD workflow logic tests (no browser required)",
 ]
 addopts = "-v --tb=short"

--- a/tests/test_ci_classify.py
+++ b/tests/test_ci_classify.py
@@ -1,0 +1,238 @@
+"""Tests for the `classify` gate in `.github/workflows/ci-cd.yml`.
+
+The gate decides whether a push gets the full lint/test/e2e suite or skips
+straight to deploy. It exists because the afk-cockpit publisher pushes a
+regenerated dashboard snapshot to `main` roughly every 31 minutes, and
+validating a data refresh with a full Playwright install is pure waste.
+
+The failure mode is silent and expensive: if the gate wrongly classifies a
+real source change as "generated only", broken code deploys to production
+with no validation at all. So the gate is tested rather than trusted, against
+a hermetic throwaway repository built per-test.
+
+The shell is extracted from the workflow itself, so these tests fail if
+someone edits the workflow logic without updating them.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.ci
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci-cd.yml"
+
+# The one file the afk-cockpit publisher rewrites. Kept in sync with the
+# GENERATED constant inside the workflow's classify step.
+GENERATED = "public/afk-cockpit/index.html"
+ZERO_SHA = "0" * 40
+
+
+@pytest.fixture(scope="session")
+def base_url() -> str:
+    """Shadow the browser suite's `base_url` fixture.
+
+    `pytest-base-url` registers a session-scoped autouse fixture that requests
+    `base_url`, and `tests/conftest.py` overrides `base_url` to build the Astro
+    site and serve `dist/` over HTTP. That makes every test in this directory —
+    including these, which never open a browser — depend on a completed build.
+    Shadowing it at module scope keeps this file runnable on a clean checkout.
+    """
+    return "http://127.0.0.1:0"
+
+
+def _classify_script() -> str:
+    """Extract the classify step's shell body from the committed workflow."""
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    steps = workflow["jobs"]["classify"]["steps"]
+    for step in steps:
+        if step.get("id") == "classify":
+            return step["run"]
+    raise AssertionError("no step with id 'classify' in the classify job")
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit(repo: Path, path: str, body: str, message: str) -> str:
+    """Write `path`, commit it, and return the resulting SHA."""
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body)
+    _git(repo, "add", "--", path)
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A throwaway git repo seeded with one generated file and one source file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "test")
+    _commit(repo, GENERATED, "<html>seed</html>\n", "seed: generated")
+    _commit(repo, "src/data/portfolio.js", "export const x = 0;\n", "seed: source")
+    return repo
+
+
+def _run(repo: Path, tmp_path: Path, event: str, before: str, sha: str) -> str:
+    """Run the extracted classify shell and return the emitted code_changed value."""
+    output_file = tmp_path / "gh_output"
+    output_file.write_text("")
+    result = subprocess.run(
+        ["bash", "-c", _classify_script()],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "EVENT": event,
+            "BEFORE": before,
+            "SHA": sha,
+            "GITHUB_OUTPUT": str(output_file),
+        },
+    )
+    assert result.returncode == 0, f"classify exited {result.returncode}:\n{result.stderr}"
+    emitted = [
+        line.split("=", 1)[1]
+        for line in output_file.read_text().splitlines()
+        if line.startswith("code_changed=")
+    ]
+    assert len(emitted) == 1, f"expected exactly one code_changed, got {emitted}"
+    return emitted[0]
+
+
+class TestSkipsGeneratedOnlyPushes:
+    """The ~48/day snapshot pushes must not pay for the full suite."""
+
+    def test_single_generated_commit_skips_validation(self, repo, tmp_path):
+        before = _git(repo, "rev-parse", "HEAD")
+        sha = _commit(repo, GENERATED, "<html>refreshed</html>\n", "chore: refresh")
+        assert _run(repo, tmp_path, "push", before, sha) == "false"
+
+    def test_several_generated_commits_in_one_push_skip_validation(self, repo, tmp_path):
+        before = _git(repo, "rev-parse", "HEAD")
+        for n in range(3):
+            sha = _commit(repo, GENERATED, f"<html>{n}</html>\n", "chore: refresh")
+        assert _run(repo, tmp_path, "push", before, sha) == "false"
+
+
+class TestValidatesRealChanges:
+    """Anything touching source must run the full suite before deploying."""
+
+    def test_source_change_runs_validation(self, repo, tmp_path):
+        before = _git(repo, "rev-parse", "HEAD")
+        sha = _commit(repo, "src/data/portfolio.js", "export const x = 1;\n", "feat: bump")
+        assert _run(repo, tmp_path, "push", before, sha) == "true"
+
+    def test_source_and_generated_together_runs_validation(self, repo, tmp_path):
+        """A mixed push must not be waved through by the generated file."""
+        before = _git(repo, "rev-parse", "HEAD")
+        _commit(repo, GENERATED, "<html>refreshed</html>\n", "chore: refresh")
+        sha = _commit(repo, "src/data/portfolio.js", "export const x = 2;\n", "feat: bump")
+        assert _run(repo, tmp_path, "push", before, sha) == "true"
+
+    def test_file_with_generated_as_prefix_runs_validation(self, repo, tmp_path):
+        """Exact-match only: a sibling path must not be mistaken for the snapshot."""
+        before = _git(repo, "rev-parse", "HEAD")
+        sha = _commit(repo, f"{GENERATED}.bak", "<html>decoy</html>\n", "chore: decoy")
+        assert _run(repo, tmp_path, "push", before, sha) == "true"
+
+
+class TestFailsOpen:
+    """An undiffable push must run everything. Never deploy unvalidated."""
+
+    def test_pull_request_event_runs_validation(self, repo, tmp_path):
+        before = _git(repo, "rev-parse", "HEAD~1")
+        sha = _git(repo, "rev-parse", "HEAD")
+        assert _run(repo, tmp_path, "pull_request", before, sha) == "true"
+
+    def test_zero_before_sha_runs_validation(self, repo, tmp_path):
+        sha = _git(repo, "rev-parse", "HEAD")
+        assert _run(repo, tmp_path, "push", ZERO_SHA, sha) == "true"
+
+    def test_empty_before_sha_runs_validation(self, repo, tmp_path):
+        sha = _git(repo, "rev-parse", "HEAD")
+        assert _run(repo, tmp_path, "push", "", sha) == "true"
+
+    def test_unreachable_before_sha_runs_validation(self, repo, tmp_path):
+        """After a force-push the before-SHA may no longer exist."""
+        sha = _git(repo, "rev-parse", "HEAD")
+        assert _run(repo, tmp_path, "push", "de" * 20, sha) == "true"
+
+    def test_empty_diff_runs_validation(self, repo, tmp_path):
+        sha = _git(repo, "rev-parse", "HEAD")
+        assert _run(repo, tmp_path, "push", sha, sha) == "true"
+
+
+class TestDeployGateWiring:
+    """The `if:` expressions are the other half of the gate; assert their shape.
+
+    `always()` is load-bearing (a skipped dependency would otherwise skip
+    deploy) and simultaneously dangerous (it would deploy through a red suite
+    unless every failure state is re-asserted). Pin both halves.
+    """
+
+    @pytest.fixture
+    def jobs(self):
+        return yaml.safe_load(WORKFLOW.read_text())["jobs"]
+
+    def test_heavy_jobs_are_gated_on_the_classifier(self, jobs):
+        for name in ("check", "e2e"):
+            assert jobs[name]["needs"] == "classify"
+            assert jobs[name]["if"] == "needs.classify.outputs.code_changed == 'true'"
+
+    def test_deploy_survives_skipped_dependencies(self, jobs):
+        assert "always()" in jobs["deploy"]["if"]
+
+    def test_deploy_refuses_failed_or_cancelled_dependencies(self, jobs):
+        condition = " ".join(jobs["deploy"]["if"].split())
+        for job in ("check", "e2e"):
+            for state in ("failure", "cancelled"):
+                assert f"needs.{job}.result != '{state}'" in condition, (
+                    f"deploy must not run when {job} is {state}"
+                )
+        assert "needs.classify.result == 'success'" in condition
+
+    def test_this_file_is_actually_selected_by_ci(self, jobs):
+        """Guard the wiring that runs these tests at all.
+
+        pytest is only ever invoked with an explicit `-m` expression, so
+        dropping `ci` from that selector would not fail anything -- this file
+        would just quietly stop running, and the classifier would go back to
+        being trusted rather than tested.
+        """
+        runs = [
+            " ".join(step["run"].split())
+            for step in jobs["e2e"]["steps"]
+            if "pytest" in str(step.get("run", ""))
+        ]
+        assert runs, "the e2e job no longer invokes pytest at all"
+        assert any(
+            "or ci" in run or '-m "ci' in run for run in runs
+        ), f"no pytest invocation selects the `ci` marker: {runs}"
+
+    def test_deploy_only_publishes_from_main_pushes(self, jobs):
+        condition = " ".join(jobs["deploy"]["if"].split())
+        assert "github.event_name == 'push'" in condition
+        assert "github.ref == 'refs/heads/main'" in condition
+
+
+def test_generated_path_matches_the_workflow():
+    """This test file and the workflow must name the same generated file."""
+    assert f"GENERATED='{GENERATED}'" in _classify_script()


### PR DESCRIPTION
## What broke

Two unrelated failures on 2026-08-06, both GitHub-side, neither caused by anything in this repo:

- **`CI / Deploy` [31117410487](https://github.com/cdcoonce/Portfolio_Website/actions/runs/31117410487)** died in `Set up job` with `Failed to resolve action download info. Error: Service Unavailable` — during a GitHub Actions **major** incident.
- **`pages build and deployment`** aborted three times (13:12Z, 13:43Z, 14:15Z) with `Timeout reached, aborting!` after polling `deployment_in_progress` — during a GitHub **Pages deployment-lag** incident.

The site never went down. This PR does not "fix" those incidents; it removes the two structural reasons they hurt.

## 1. Stop validating a generated file

The afk-cockpit publisher (`com.cdcoonce.afk-cockpit-publish`, launchd, every 31 min) pushes straight to `main`, rewriting **three lines of one generated file**, `public/afk-cockpit/index.html`. Every push ran prettier, stylelint, eslint, Jest, a full Playwright browser install and the DOM suite — **~48 full pipelines a day to validate a data refresh**, and 48 daily chances for a transient Actions blip to page you about code that did not change.

A new `classify` job diffs the push range and gates `check` and `e2e` on it. **The snapshot still deploys immediately** — it has to stay fresh in production.

The classifier **fails open**. Non-push events, a missing or all-zero before-SHA, a before-SHA made unreachable by a force-push, and empty diffs all fall back to full validation. A wrong guess must cost a wasted run, never an unvalidated deploy.

`deploy` now needs `always()` — a skipped `check` would otherwise skip it too. Since `always()` on its own would cheerfully deploy through a red suite, every failure and cancellation state is re-asserted explicitly.

## 2. Deploy Pages natively

Publishing went `peaceiris/actions-gh-pages` → `gh-pages` branch → GitHub's **implicit** `pages build and deployment` workflow. That builder is not defined in this repo, so its poll timeout was not tunable — which is exactly why Pages lag surfaced as hard failures instead of slow successes.

Now: `configure-pages` + `upload-pages-artifact` + `deploy-pages`, with `timeout: 1800000` (30 min, up from the 10-minute default). One less hop, no implicit second workflow, and the timeout is a knob we own.

Also asserts `dist/CNAME` exists before upload — a silently dropped CNAME would move the site off `charleslikesdata.com` without failing anything.

## Verification

`tests/test_ci_classify.py` — 16 tests, hermetic (builds a throwaway git repo per test; needs no `dist/`). The shell is **extracted from the workflow itself**, so the tests fail if the logic changes without them.

Mutation-tested; all 7 injected defects were caught:

| Mutation | Result |
| --- | --- |
| Invert the snapshot match (`grep -Fxv` → `-Fx`) | 4 failed |
| Drop the force-push fail-open guard | 1 failed |
| Let `deploy` run through a failed `check` | 1 failed |
| Let `deploy` run through a cancelled `e2e` | 1 failed |
| `always()` → `success()` | 1 failed |
| Generated path drifts out of sync | 3 failed |
| Drop `ci` from the pytest selector | 1 failed |

That last one matters: pytest is only ever invoked with an explicit `-m` expression, so without a guard these tests would silently stop running rather than fail.

No file in the `format:check` glob (`**/*.{html,css,js,md,json}`) is touched, so the Node-side gate is unaffected.

## ⚠️ Merging this requires a settings change

`actions/deploy-pages` needs **Settings → Pages → Source = "GitHub Actions"** (`build_type=workflow`; currently `legacy`). **The deploy job fails until that flip happens.**

Recommended order — flip first, then merge:

1. Set Pages source to "GitHub Actions". The site keeps serving its last successful deployment; only new publishes pause.
2. Merge this PR. The next push deploys natively.
3. Confirm `https://charleslikesdata.com/` still resolves with a valid cert and the custom domain survived.

Merging before the flip is recoverable — the deploy job fails, the site stays up on its last deployment, and re-running after flipping fixes it.

The `gh-pages` branch becomes vestigial after this and can be deleted once a native deploy is confirmed green.
